### PR TITLE
Fix multi-path returned from `_path` methods on MacOS

### DIFF
--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -91,6 +91,12 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
         if self.ensure_exists:
             Path(path).mkdir(parents=True, exist_ok=True)
 
+    def _first_item_as_path_if_multipath(self, directory: str) -> Path:
+        if self.multipath:
+            # If multipath is True, the first path is returned.
+            directory = directory.split(os.pathsep)[0]
+        return Path(directory)
+
     @property
     @abstractmethod
     def user_data_dir(self) -> str:

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import os.path
 import sys
+from typing import TYPE_CHECKING
 
 from .api import PlatformDirsABC
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class MacOS(PlatformDirsABC):
@@ -43,6 +47,11 @@ class MacOS(PlatformDirsABC):
         return path_list[0]
 
     @property
+    def site_data_path(self) -> Path:
+        """:return: data path shared by users. Only return the first item, even if ``multipath`` is set to ``True``"""
+        return self._first_item_as_path_if_multipath(self.site_data_dir)
+
+    @property
     def user_config_dir(self) -> str:
         """:return: config directory tied to the user, same as `user_data_dir`"""
         return self.user_data_dir
@@ -73,6 +82,11 @@ class MacOS(PlatformDirsABC):
         if self.multipath:
             return os.pathsep.join(path_list)
         return path_list[0]
+
+    @property
+    def site_cache_path(self) -> Path:
+        """:return: cache path shared by users. Only return the first item, even if ``multipath`` is set to ``True``"""
+        return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
     @property
     def user_state_dir(self) -> str:

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -218,12 +218,6 @@ class Unix(PlatformDirsABC):  # noqa: PLR0904
         """:return: cache path shared by users. Only return the first item, even if ``multipath`` is set to ``True``"""
         return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
-    def _first_item_as_path_if_multipath(self, directory: str) -> Path:
-        if self.multipath:
-            # If multipath is True, the first path is returned.
-            directory = directory.split(os.pathsep)[0]
-        return Path(directory)
-
     def iter_config_dirs(self) -> Iterator[str]:
         """:yield: all user and site configuration directories."""
         yield self.user_config_dir

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -82,6 +82,8 @@ def test_macos(mocker: MockerFixture, params: dict[str, Any], func: str) -> None
         "site_config_dir",
         "site_cache_dir",
         "site_runtime_dir",
+        "site_cache_path",
+        "site_data_path",
     ],
 )
 @pytest.mark.parametrize("multipath", [pytest.param(True, id="multipath"), pytest.param(False, id="singlepath")])
@@ -94,6 +96,10 @@ def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath
     suffix_elements = tuple(params[i] for i in ("appname", "version") if i in params)
     suffix = os.sep.join(("", *suffix_elements)) if suffix_elements else ""  # noqa: PTH118
 
+    expected_path_map = {
+        "site_cache_path": Path(f"/opt/homebrew/var/cache{suffix}"),
+        "site_data_path": Path(f"/opt/homebrew/share{suffix}"),
+    }
     expected_map = {
         "site_data_dir": f"/opt/homebrew/share{suffix}",
         "site_config_dir": f"/opt/homebrew/share{suffix}",
@@ -104,6 +110,6 @@ def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath
         expected_map["site_data_dir"] += f":/Library/Application Support{suffix}"
         expected_map["site_config_dir"] += f":/Library/Application Support{suffix}"
         expected_map["site_cache_dir"] += f":/Library/Caches{suffix}"
-    expected = expected_map[site_func]
+    expected = expected_path_map[site_func] if site_func.endswith("_path") else expected_map[site_func]
 
     assert result == expected


### PR DESCRIPTION
Fix `site_{data,cache}_path` returning `pathlib.Path` based on the entire `:` separated multipath under Homebrew with `multipath` enabled. Instead, follow the approach used by `Unix` and only return the first element if we're `multipath`

These were the only two attributes that changed when under `homebrew`

Issue: 292