### PR TITLE
don't include outdated changelog in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,7 @@
 platformdirs Changelog
 ======================
 
-platformdirs 4.1.0 (2024-01-XX)
--------------------------------
-- Add convenience methods ``iter_{config,cache,data,runtime}_{dirs,paths}``.
+The changes of more recent versions are tracked at https://github.com/tox-dev/platformdirs/releases
 
 platformdirs 4.0.0 (2023-11-10)
 -------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 platformdirs Changelog
 ======================
 
-The changes of more recent versions are tracked at https://github.com/tox-dev/platformdirs/releases
+The changes of more recent versions are `tracked here <https://github.com/tox-dev/platformdirs/releases>`_.
 
 platformdirs 4.0.0 (2023-11-10)
 -------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,0 @@
-.. include:: ../CHANGES.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,6 @@ The source code and issue tracker are both hosted on `GitHub`_.
    :maxdepth: 3
 
    api
-   changelog
 
 Indices and tables
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ optional-dependencies.test = [
 optional-dependencies.type = [
   "mypy>=1.11.2",
 ]
-urls.Changelog = "https://github.com/platformdirs/platformdirs/releases"
 
+urls.Changelog = "https://github.com/platformdirs/platformdirs/releases"
 urls.Documentation = "https://platformdirs.readthedocs.io"
 urls.Homepage = "https://github.com/platformdirs/platformdirs"
 urls.Source = "https://github.com/platformdirs/platformdirs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ urls.Documentation = "https://platformdirs.readthedocs.io"
 urls.Homepage = "https://github.com/platformdirs/platformdirs"
 urls.Source = "https://github.com/platformdirs/platformdirs"
 urls.Tracker = "https://github.com/platformdirs/platformdirs/issues"
+urls.Changelog = "https://github.com/platformdirs/platformdirs/releases"
 
 [tool.hatch]
 build.hooks.vcs.version-file = "src/platformdirs/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,11 @@ optional-dependencies.type = [
   "mypy>=1.11.2",
 ]
 
-urls.Changelog = "https://github.com/platformdirs/platformdirs/releases"
+urls.Changelog = "https://github.com/tox-dev/platformdirs/releases"
 urls.Documentation = "https://platformdirs.readthedocs.io"
-urls.Homepage = "https://github.com/platformdirs/platformdirs"
-urls.Source = "https://github.com/platformdirs/platformdirs"
-urls.Tracker = "https://github.com/platformdirs/platformdirs/issues"
+urls.Homepage = "https://github.com/tox-dev/platformdirs"
+urls.Source = "https://github.com/tox-dev/platformdirs"
+urls.Tracker = "https://github.com/tox-dev/platformdirs/issues"
 
 [tool.hatch]
 build.hooks.vcs.version-file = "src/platformdirs/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,12 @@ optional-dependencies.test = [
 optional-dependencies.type = [
   "mypy>=1.11.2",
 ]
+urls.Changelog = "https://github.com/platformdirs/platformdirs/releases"
+
 urls.Documentation = "https://platformdirs.readthedocs.io"
 urls.Homepage = "https://github.com/platformdirs/platformdirs"
 urls.Source = "https://github.com/platformdirs/platformdirs"
 urls.Tracker = "https://github.com/platformdirs/platformdirs/issues"
-urls.Changelog = "https://github.com/platformdirs/platformdirs/releases"
 
 [tool.hatch]
 build.hooks.vcs.version-file = "src/platformdirs/version.py"


### PR DESCRIPTION
I noticed the changelog at https://platformdirs.readthedocs.io/en/latest/changelog.html wasn't being maintained.   Here I remove it from the docs.  In the CHANGES.rst file itself, I left a link to the GitHub releases.