### PR TITLE
Drop support for EOL Python 3.8

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,7 +26,6 @@ jobs:
           - "3.11"
           - "3.10"
           - "3.9"
-          - "3.8"
         os:
           - ubuntu-latest
           - windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [
   { name = "Ofek Lev", email = "oss@ofek.dev" },
   { name = "Ronny Pfannschmidt", email = "opensource@ronnypfannschmidt.de" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -32,7 +32,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -102,7 +101,6 @@ matrix = [
     "3.11",
     "3.10",
     "3.9",
-    "3.8",
     "pypy3.10",
   ] },
 ]
@@ -203,40 +201,41 @@ scripts = { "run" = [
 ] }
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 format.preview = true
-lint.preview = true
-select = [
+lint.select = [
   "ALL",
 ]
-isort = { known-first-party = [
+lint.ignore = [
+  "ANN101", # Missing type annotation for `self` in method
+  "CPY",    # no copyright notices
+  "D203",   # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible
+  "D205",   # 1 blank line required between summary line and description
+  "D212",   # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible
+  "D301",   # Use `r"""` if any backslashes in a docstring
+  "D401",   # The first line of docstring should be in imperative mood
+  "DOC",    # no support for restructuredtext
+  "S104",   # Possible binding to all interfaces
+]
+lint.per-file-ignores."tests/**/*.py" = [
+  "D",       # don't care about documentation in tests
+  "FBT",     # don't care about booleans as positional arguments in tests
+  "INP001",  # no implicit namespace
+  "PLC2701", # Private name import
+  "PLR0917", # Too many positional arguments
+  "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
+  "S101",    # asserts allowed in tests
+  "S603",    # `subprocess` call: check for execution of untrusted input
+]
+
+lint.isort = { known-first-party = [
   "platformdirs",
   "tests",
 ], required-imports = [
   "from __future__ import annotations",
 ] }
-ignore = [
-  "ANN101", # Missing type annotation for `self` in method
-  "D301",   # Use `r"""` if any backslashes in a docstring
-  "D205",   # 1 blank line required between summary line and description
-  "D401",   # The first line of docstring should be in imperative mood
-  "D203",   # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible
-  "D212",   # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible
-  "S104",   # Possible binding to all interfaces
-  "CPY",    # no copyright notices
-  "DOC",    # no support for restructuredtext
-]
-per-file-ignores."tests/**/*.py" = [
-  "S101",    # asserts allowed in tests
-  "FBT",     # don't care about booleans as positional arguments in tests
-  "INP001",  # no implicit namespace
-  "D",       # don't care about documentation in tests
-  "S603",    # `subprocess` call: check for execution of untrusted input
-  "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
-  "PLC2701", # Private name import
-  "PLR0917", # Too many positional arguments
-]
+lint.preview = true
 
 [tool.codespell]
 builtin = "clear,usage,en-GB_to_en-US"

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterator, Literal
+    from collections.abc import Iterator
+    from typing import Literal
 
 
 class PlatformDirsABC(ABC):  # noqa: PLR0904

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -6,9 +6,12 @@ import os
 import sys
 from configparser import ConfigParser
 from pathlib import Path
-from typing import Iterator, NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
 from .api import PlatformDirsABC
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 if sys.platform == "win32":
 


### PR DESCRIPTION
Python 3.8 reached EOL in October 2024:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/
