### PR TITLE
feat: improve homebrew path detection

### DIFF
--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -34,13 +34,14 @@ class MacOS(PlatformDirsABC):
         """
         :return: data directory shared by users, e.g. ``/Library/Application Support/$appname/$version``.
           If we're using a Python binary managed by `Homebrew <https://brew.sh>`_, the directory
-          will be under the Homebrew prefix, e.g. ``/opt/homebrew/share/$appname/$version``.
+          will be under the Homebrew prefix, e.g. ``$homebrew_prefix/share/$appname/$version``.
           If `multipath <platformdirs.api.PlatformDirsABC.multipath>` is enabled, and we're in Homebrew,
           the response is a multi-path string separated by ":", e.g.
-          ``/opt/homebrew/share/$appname/$version:/Library/Application Support/$appname/$version``
+          ``$homebrew_prefix/share/$appname/$version:/Library/Application Support/$appname/$version``
         """
-        is_homebrew = sys.prefix.startswith("/opt/homebrew")
-        path_list = [self._append_app_name_and_version("/opt/homebrew/share")] if is_homebrew else []
+        is_homebrew = "/opt/python" in sys.prefix
+        homebrew_prefix = sys.prefix.split("/opt/python")[0] if is_homebrew else ""
+        path_list = [self._append_app_name_and_version(f"{homebrew_prefix}/share")] if is_homebrew else []
         path_list.append(self._append_app_name_and_version("/Library/Application Support"))
         if self.multipath:
             return os.pathsep.join(path_list)
@@ -71,13 +72,14 @@ class MacOS(PlatformDirsABC):
         """
         :return: cache directory shared by users, e.g. ``/Library/Caches/$appname/$version``.
           If we're using a Python binary managed by `Homebrew <https://brew.sh>`_, the directory
-          will be under the Homebrew prefix, e.g. ``/opt/homebrew/var/cache/$appname/$version``.
+          will be under the Homebrew prefix, e.g. ``$homebrew_prefix/var/cache/$appname/$version``.
           If `multipath <platformdirs.api.PlatformDirsABC.multipath>` is enabled, and we're in Homebrew,
           the response is a multi-path string separated by ":", e.g.
-          ``/opt/homebrew/var/cache/$appname/$version:/Library/Caches/$appname/$version``
+          ``$homebrew_prefix/var/cache/$appname/$version:/Library/Caches/$appname/$version``
         """
-        is_homebrew = sys.prefix.startswith("/opt/homebrew")
-        path_list = [self._append_app_name_and_version("/opt/homebrew/var/cache")] if is_homebrew else []
+        is_homebrew = "/opt/python" in sys.prefix
+        homebrew_prefix = sys.prefix.split("/opt/python")[0] if is_homebrew else ""
+        path_list = [self._append_app_name_and_version(f"{homebrew_prefix}/var/cache")] if is_homebrew else []
         path_list.append(self._append_app_name_and_version("/Library/Caches"))
         if self.multipath:
             return os.pathsep.join(path_list)

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -91,16 +91,16 @@ def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath
     test_data = [
         {
             "sys_prefix": "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13",
-            "homebrew_prefix": "/opt/homebrew"
+            "homebrew_prefix": "/opt/homebrew",
         },
         {
             "sys_prefix": "/usr/local/opt/python@3.13/Frameworks/Python.framework/Versions/3.13",
-            "homebrew_prefix": "/usr/local"
+            "homebrew_prefix": "/usr/local",
         },
         {
             "sys_prefix": "/myown/arbitrary/prefix/opt/python@3.13/Frameworks/Python.framework/Versions/3.13",
-            "homebrew_prefix": "/myown/arbitrary/prefix"
-        }
+            "homebrew_prefix": "/myown/arbitrary/prefix",
+        },
     ]
     for prefix in test_data:
         mocker.patch("sys.prefix", prefix["sys_prefix"])

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -88,28 +88,43 @@ def test_macos(mocker: MockerFixture, params: dict[str, Any], func: str) -> None
 )
 @pytest.mark.parametrize("multipath", [pytest.param(True, id="multipath"), pytest.param(False, id="singlepath")])
 def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath: bool, site_func: str) -> None:
-    mocker.patch("sys.prefix", "/opt/homebrew/opt/python")
+    test_data = [
+        {
+            "sys_prefix": "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13",
+            "homebrew_prefix": "/opt/homebrew"
+        },
+        {
+            "sys_prefix": "/usr/local/opt/python@3.13/Frameworks/Python.framework/Versions/3.13",
+            "homebrew_prefix": "/usr/local"
+        },
+        {
+            "sys_prefix": "/myown/arbitrary/prefix/opt/python@3.13/Frameworks/Python.framework/Versions/3.13",
+            "homebrew_prefix": "/myown/arbitrary/prefix"
+        }
+    ]
+    for prefix in test_data:
+        mocker.patch("sys.prefix", prefix["sys_prefix"])
 
-    result = getattr(MacOS(multipath=multipath, **params), site_func)
+        result = getattr(MacOS(multipath=multipath, **params), site_func)
 
-    home = str(Path("~").expanduser())
-    suffix_elements = tuple(params[i] for i in ("appname", "version") if i in params)
-    suffix = os.sep.join(("", *suffix_elements)) if suffix_elements else ""  # noqa: PTH118
+        home = str(Path("~").expanduser())
+        suffix_elements = tuple(params[i] for i in ("appname", "version") if i in params)
+        suffix = os.sep.join(("", *suffix_elements)) if suffix_elements else ""  # noqa: PTH118
 
-    expected_path_map = {
-        "site_cache_path": Path(f"/opt/homebrew/var/cache{suffix}"),
-        "site_data_path": Path(f"/opt/homebrew/share{suffix}"),
-    }
-    expected_map = {
-        "site_data_dir": f"/opt/homebrew/share{suffix}",
-        "site_config_dir": f"/opt/homebrew/share{suffix}",
-        "site_cache_dir": f"/opt/homebrew/var/cache{suffix}",
-        "site_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
-    }
-    if multipath:
-        expected_map["site_data_dir"] += f":/Library/Application Support{suffix}"
-        expected_map["site_config_dir"] += f":/Library/Application Support{suffix}"
-        expected_map["site_cache_dir"] += f":/Library/Caches{suffix}"
-    expected = expected_path_map[site_func] if site_func.endswith("_path") else expected_map[site_func]
+        expected_path_map = {
+            "site_cache_path": Path(f"{prefix['homebrew_prefix']}/var/cache{suffix}"),
+            "site_data_path": Path(f"{prefix['homebrew_prefix']}/share{suffix}"),
+        }
+        expected_map = {
+            "site_data_dir": f"{prefix['homebrew_prefix']}/share{suffix}",
+            "site_config_dir": f"{prefix['homebrew_prefix']}/share{suffix}",
+            "site_cache_dir": f"{prefix['homebrew_prefix']}/var/cache{suffix}",
+            "site_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
+        }
+        if multipath:
+            expected_map["site_data_dir"] += f":/Library/Application Support{suffix}"
+            expected_map["site_config_dir"] += f":/Library/Application Support{suffix}"
+            expected_map["site_cache_dir"] += f":/Library/Caches{suffix}"
+        expected = expected_path_map[site_func] if site_func.endswith("_path") else expected_map[site_func]
 
-    assert result == expected
+        assert result == expected


### PR DESCRIPTION
Improve homebrew installed python detection.

This will detect the users that not only arm macos users but also intel macos users. And even if user change their homebrew prefix, this could catch them and use the path for that. I am not pretending to get the 100% users but just increase the chance of this.

Well, there is another option that just use HOMEBREW_PREFIX directly. But it depends on the user configuration and system so I didn't tried.

Here is my local output with homebrew installed python.

```sh
python3.12 -c "import sys; print(sys.prefix)"
/opt/homebrew/opt/python@3.12/Frameworks/Python.framework/Versions/3.12
python3.13 -c "import sys; print(sys.prefix)"
/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13
```