### PR TITLE
feat: Make user_cache_dir respect temporary directory environment variables

### DIFF
--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Literal
 
-TEMP_ENV_VARS = "TMPDIR", "TEMPDIR", "TEMP", "TMP"
-"""A tuple of environment variables that can be used to override the cache directory."""
+TEMP_ENV_VARS = "TMPDIR", "TEMPDIR", "TEMP", "TMP"  #: Environment variables that can be used to override the cache directory.
 
 
 class PlatformDirsABC(ABC):  # noqa: PLR0904
@@ -105,10 +104,7 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
     @final
     def _get_temp_dir() -> str | None:
         """Get the temporary directory from environment variables."""
-        for var in TEMP_ENV_VARS:
-            if value := os.environ.get(var, "").strip():
-                return value
-        return None
+        return next((os.environ.get(var) for var in TEMP_ENV_VARS if os.environ.get(var, "").strip()), None)
 
     @property
     @abstractmethod

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, final
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Literal
+
+TEMP_ENV_VARS = "TMPDIR", "TEMPDIR", "TEMP", "TMP"
+"""A tuple of environment variables that can be used to override the cache directory."""
 
 
 class PlatformDirsABC(ABC):  # noqa: PLR0904
@@ -97,6 +100,15 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
             # If multipath is True, the first path is returned.
             directory = directory.partition(os.pathsep)[0]
         return Path(directory)
+
+    @staticmethod
+    @final
+    def _get_temp_dir() -> str | None:
+        """Get the temporary directory from environment variables."""
+        for var in TEMP_ENV_VARS:
+            if value := os.environ.get(var, "").strip():
+                return value
+        return None
 
     @property
     @abstractmethod

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -11,7 +11,12 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Literal
 
-TEMP_ENV_VARS = "TMPDIR", "TEMPDIR", "TEMP", "TMP"  #: Environment variables that can be used to override the cache directory.
+TEMP_ENV_VARS = (
+    "TMPDIR",
+    "TEMPDIR",
+    "TEMP",
+    "TMP",
+)  #: Environment variables that can be used to override the cache directory.
 
 
 class PlatformDirsABC(ABC):  # noqa: PLR0904

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import os.path
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from .api import PlatformDirsABC
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class MacOS(PlatformDirsABC):

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -68,7 +68,7 @@ class MacOS(PlatformDirsABC):
         :return: cache directory tied to the user, e.g. ``~/Library/Caches/$appname/$version``. It is also
           possible to override this via the ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
         """
-        path = self._get_temp_dir() or os.path.expanduser("~/Library/Caches")
+        path = self._get_temp_dir() or str(Path("~/Library/Caches").expanduser())
         return self._append_app_name_and_version(path)
 
     @property

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -64,8 +64,14 @@ class MacOS(PlatformDirsABC):
 
     @property
     def user_cache_dir(self) -> str:
-        """:return: cache directory tied to the user, e.g. ``~/Library/Caches/$appname/$version``"""
-        return self._append_app_name_and_version(os.path.expanduser("~/Library/Caches"))  # noqa: PTH111
+        """
+        :return: cache directory tied to the user, e.g. ``~/Library/Caches/$appname/$version``. It is also
+          possible to override this via the ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
+        """
+        path = self._get_temp_dir()
+        if path is None:
+            path = os.path.expanduser("~/Library/Caches")  # noqa: PTH111
+        return self._append_app_name_and_version(path)
 
     @property
     def site_cache_dir(self) -> str:

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -68,9 +68,7 @@ class MacOS(PlatformDirsABC):
         :return: cache directory tied to the user, e.g. ``~/Library/Caches/$appname/$version``. It is also
           possible to override this via the ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
         """
-        path = self._get_temp_dir()
-        if path is None:
-            path = os.path.expanduser("~/Library/Caches")  # noqa: PTH111
+        path = self._get_temp_dir() or os.path.expanduser("~/Library/Caches")
         return self._append_app_name_and_version(path)
 
     @property

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -102,10 +102,13 @@ class Unix(PlatformDirsABC):  # noqa: PLR0904
     def user_cache_dir(self) -> str:
         """
         :return: cache directory tied to the user, e.g. ``~/.cache/$appname/$version`` or
-         ``~/$XDG_CACHE_HOME/$appname/$version``
+         ``~/$XDG_CACHE_HOME/$appname/$version``. It is also possible to override this via the
+         ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
         """
-        path = os.environ.get("XDG_CACHE_HOME", "")
-        if not path.strip():
+        path = os.environ.get("XDG_CACHE_HOME", "").strip()
+        if not path:
+            path = self._get_temp_dir()
+        if not path:
             path = os.path.expanduser("~/.cache")  # noqa: PTH111
         return self._append_app_name_and_version(path)
 

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -105,11 +105,11 @@ class Unix(PlatformDirsABC):  # noqa: PLR0904
          ``~/$XDG_CACHE_HOME/$appname/$version``. It is also possible to override this via the
          ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
         """
-        path = os.environ.get("XDG_CACHE_HOME", "").strip()
-        if not path:
-            path = self._get_temp_dir()
-        if not path:
-            path = os.path.expanduser("~/.cache")  # noqa: PTH111
+        path = (
+            os.environ.get("XDG_CACHE_HOME", "").strip()
+            or self._get_temp_dir()
+            or os.path.expanduser("~/.cache")
+        )
         return self._append_app_name_and_version(path)
 
     @property

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -105,11 +105,7 @@ class Unix(PlatformDirsABC):  # noqa: PLR0904
          ``~/$XDG_CACHE_HOME/$appname/$version``. It is also possible to override this via the
          ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
         """
-        path = (
-            os.environ.get("XDG_CACHE_HOME", "").strip()
-            or self._get_temp_dir()
-            or os.path.expanduser("~/.cache")
-        )
+        path = os.environ.get("XDG_CACHE_HOME", "").strip() or self._get_temp_dir() or Path("~/.cache").expanduser()
         return self._append_app_name_and_version(path)
 
     @property

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -73,9 +73,7 @@ class Windows(PlatformDirsABC):
          ``%USERPROFILE%\\AppData\\Local\\$appauthor\\$appname\\Cache\\$version``. It is also possible to override
          this via the ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
         """
-        path = self._get_temp_dir()
-        if path is None:
-            path = os.path.normpath(get_win_folder("CSIDL_LOCAL_APPDATA"))
+        path = self._get_temp_dir() or os.path.normpath(get_win_folder("CSIDL_LOCAL_APPDATA"))
         return self._append_parts(path, opinion_value="Cache")
 
     @property

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -70,9 +70,12 @@ class Windows(PlatformDirsABC):
     def user_cache_dir(self) -> str:
         """
         :return: cache directory tied to the user (if opinionated with ``Cache`` folder within ``$appname``) e.g.
-         ``%USERPROFILE%\\AppData\\Local\\$appauthor\\$appname\\Cache\\$version``
+         ``%USERPROFILE%\\AppData\\Local\\$appauthor\\$appname\\Cache\\$version``. It is also possible to override
+         this via the ``TMPDIR``, ``TEMPDIR``, ``TEMP``, and ``TMP`` environment variables.
         """
-        path = os.path.normpath(get_win_folder("CSIDL_LOCAL_APPDATA"))
+        path = self._get_temp_dir()
+        if path is None:
+            path = os.path.normpath(get_win_folder("CSIDL_LOCAL_APPDATA"))
         return self._append_parts(path, opinion_value="Cache")
 
     @property

--- a/tests/test_comp_with_appdirs.py
+++ b/tests/test_comp_with_appdirs.py
@@ -54,7 +54,7 @@ def test_compatibility(params: dict[str, Any], func: str) -> None:
     if getattr(appdirs, func, None) is None:
         pytest.skip(f"`{func}` does not exist in `appdirs`")
 
-    msg = { "user_cache_dir": "appdirs does not support temp dir overriding by env vars"}
+    msg = {"user_cache_dir": "appdirs does not support temp dir overriding by env vars"}
     if sys.platform == "darwin":
         msg["user_log_dir"] = "without appname produces NoneType error"
         if func in msg:  # pragma: no cover

--- a/tests/test_comp_with_appdirs.py
+++ b/tests/test_comp_with_appdirs.py
@@ -54,16 +54,13 @@ def test_compatibility(params: dict[str, Any], func: str) -> None:
     if getattr(appdirs, func, None) is None:
         pytest.skip(f"`{func}` does not exist in `appdirs`")
 
+    msg = { "user_cache_dir": "appdirs does not support temp dir overriding by env vars"}
     if sys.platform == "darwin":
-        msg = {  # pragma: no cover
-            "user_log_dir": "without appname produces NoneType error",
-        }
+        msg["user_log_dir"] = "without appname produces NoneType error"
         if func in msg:  # pragma: no cover
             pytest.skip(f"`appdirs.{func}` {msg[func]} on macOS")  # pragma: no cover
     elif sys.platform != "win32":
-        msg = {  # pragma: no cover
-            "user_log_dir": "Uses XDG_STATE_DIR instead of appdirs.user_data_dir per the XDG spec",
-        }
+        msg["user_log_dir"] = "Uses XDG_STATE_DIR instead of appdirs.user_data_dir per the XDG spec"
         if func in msg:  # pragma: no cover
             pytest.skip(f"`appdirs.{func}` {msg[func]} on Unix")  # pragma: no cover
 

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -22,7 +22,7 @@ def _fix_os_pathsep(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _unset_temp_env_vars(monkeypatch: "pytest.MonkeyPatch") -> None:
+def _unset_temp_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure canonical temp env vars are unset for tests that rely on macOS defaults."""
     for name in ("TMPDIR", "TEMPDIR", "TEMP", "TMP"):
         monkeypatch.delenv(name, raising=False)

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -21,6 +21,13 @@ def _fix_os_pathsep(mocker: MockerFixture) -> None:
         mocker.patch("os.path.pathsep", ":")
 
 
+@pytest.fixture(autouse=True)
+def _unset_temp_env_vars(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """Ensure canonical temp env vars are unset for tests that rely on macOS defaults."""
+    for name in ("TMPDIR", "TEMPDIR", "TEMP", "TMP"):
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.mark.parametrize(
     "params",
     [

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -8,6 +8,7 @@ import typing
 import pytest
 
 from platformdirs import unix
+from platformdirs.api import TEMP_ENV_VARS
 from platformdirs.unix import Unix
 
 if typing.TYPE_CHECKING:
@@ -120,6 +121,9 @@ def test_xdg_variable_not_set(monkeypatch: pytest.MonkeyPatch, dirs_instance: Un
         return
 
     monkeypatch.delenv(xdg_variable.name, raising=False)
+    for name in TEMP_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
     result = getattr(dirs_instance, func)
     assert result == os.path.expanduser(xdg_variable.default_value)  # noqa: PTH111
 
@@ -131,6 +135,8 @@ def test_xdg_variable_empty_value(monkeypatch: pytest.MonkeyPatch, dirs_instance
         return
 
     monkeypatch.setenv(xdg_variable.name, "")
+    for name in TEMP_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
     result = getattr(dirs_instance, func)
     assert result == os.path.expanduser(xdg_variable.default_value)  # noqa: PTH111
 

--- a/tests/test_user_cache_dir.py
+++ b/tests/test_user_cache_dir.py
@@ -12,6 +12,10 @@ if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
 
 
+def test_temp_env_vars_defined_and_ordered() -> None:
+    """Ensure the canonical set of temp env vars stays intact"""
+    assert TEMP_ENV_VARS == ("TMPDIR", "TEMPDIR", "TEMP", "TMP")
+
 @pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
 def test_user_cache_dir_linux_xdg_home_set(monkeypatch: MonkeyPatch, prop: str) -> None:
     """Test the user cache directory on Linux when XDG_CACHE_HOME is set."""

--- a/tests/test_user_cache_dir.py
+++ b/tests/test_user_cache_dir.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from platformdirs.api import TEMP_ENV_VARS
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
+def test_user_cache_dir_linux_xdg_home_set(monkeypatch: MonkeyPatch, prop: str) -> None:
+    """Test the user cache directory on Linux when XDG_CACHE_HOME is set."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    from platformdirs.unix import Unix as PlatformDirs  # noqa: PLC0415
+
+    monkeypatch.setenv("XDG_CACHE_HOME", "/home/user/.cache-xdg")
+    monkeypatch.setenv("HOME", "/home/user")
+
+    dirs = PlatformDirs("MyApp", "MyCompany")
+    result = getattr(dirs, prop)
+    expected = Path("/home/user/.cache-xdg/MyApp")
+
+    assert result == (str(expected) if prop == "user_cache_dir" else expected)
+
+
+@pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
+@pytest.mark.parametrize("env_var", TEMP_ENV_VARS)
+def test_user_cache_dir_linux_tmp_set(monkeypatch: MonkeyPatch, prop: str, env_var: str) -> None:
+    """Test the user cache directory on Linux when a temp env var is set."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    from platformdirs.unix import Unix as PlatformDirs  # noqa: PLC0415
+
+    monkeypatch.setenv(env_var, "/tmp/some-dir")  # noqa: S108
+    monkeypatch.setenv("HOME", "/home/user")
+
+    # Unset other temp vars to ensure priority is tested
+    for var in set(TEMP_ENV_VARS) - {env_var}:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+    dirs = PlatformDirs("MyApp", "MyCompany")
+    result = getattr(dirs, prop)
+    expected = Path("/tmp/some-dir/MyApp")  # noqa: S108
+
+    assert result == (str(expected) if prop == "user_cache_dir" else expected)
+
+
+@pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
+def test_user_cache_dir_linux_fallback(monkeypatch: MonkeyPatch, prop: str) -> None:
+    """Test the user cache directory on Linux as a fallback."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    from platformdirs.unix import Unix as PlatformDirs  # noqa: PLC0415
+
+    monkeypatch.setenv("HOME", "/home/user")
+    for var in TEMP_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+    dirs = PlatformDirs("MyApp", "MyCompany")
+    result = getattr(dirs, prop)
+    expected = Path("/home/user/.cache/MyApp")
+
+    assert result == (str(expected) if prop == "user_cache_dir" else expected)
+
+
+@pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
+@pytest.mark.parametrize("env_var", TEMP_ENV_VARS)
+def test_user_cache_dir_macos_tmp_set(monkeypatch: MonkeyPatch, prop: str, env_var: str) -> None:
+    """Test the user cache directory on macOS when a temp env var is set."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    from platformdirs.macos import MacOS as PlatformDirs  # noqa: PLC0415
+
+    monkeypatch.setenv(env_var, "/tmp/some-dir")  # noqa: S108
+    monkeypatch.setenv("HOME", "/home/user")
+
+    # Unset other temp vars to ensure priority is tested
+    for var in set(TEMP_ENV_VARS) - {env_var}:
+        monkeypatch.delenv(var, raising=False)
+
+    dirs = PlatformDirs("MyApp", "MyCompany")
+    result = getattr(dirs, prop)
+    expected = Path("/tmp/some-dir/MyApp")  # noqa: S108
+
+    assert result == (str(expected) if prop == "user_cache_dir" else expected)
+
+
+@pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
+def test_user_cache_dir_macos_fallback(monkeypatch: MonkeyPatch, prop: str) -> None:
+    """Test the user cache directory on macOS as a fallback."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    from platformdirs.macos import MacOS as PlatformDirs  # noqa: PLC0415
+
+    monkeypatch.setenv("HOME", "/home/user")
+    for var in TEMP_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    dirs = PlatformDirs("MyApp", "MyCompany")
+    result = getattr(dirs, prop)
+    expected = Path("/home/user/Library/Caches/MyApp")
+
+    assert result == (str(expected) if prop == "user_cache_dir" else expected)
+
+
+@pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
+@pytest.mark.parametrize("env_var", TEMP_ENV_VARS)
+def test_user_cache_dir_windows_tmp_set(monkeypatch: MonkeyPatch, prop: str, env_var: str) -> None:
+    """Test the user cache directory on Windows when a temp env var is set."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    from platformdirs.windows import Windows as PlatformDirs  # noqa: PLC0415
+
+    monkeypatch.setenv(env_var, "C:\\Temp\\some-dir")
+
+    # Unset other temp vars to ensure priority is tested
+    for var in set(TEMP_ENV_VARS) - {env_var}:
+        monkeypatch.delenv(var, raising=False)
+
+    dirs = PlatformDirs("MyApp", "MyCompany")
+    result = str(getattr(dirs, prop))
+    expected = str(Path("C:\\Temp\\some-dir\\MyCompany\\MyApp\\Cache"))
+
+    assert result.replace("\\", "/") == expected.replace("\\", "/")
+
+
+@pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
+def test_user_cache_dir_windows_fallback(monkeypatch: MonkeyPatch, prop: str) -> None:
+    """Test the user cache directory on Windows as a fallback."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    from platformdirs.windows import Windows as PlatformDirs  # noqa: PLC0415
+
+    monkeypatch.setenv("LOCALAPPDATA", "C:\\Users\\user\\AppData\\Local")
+    for var in TEMP_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    dirs = PlatformDirs("MyApp", "MyCompany")
+    result = str(getattr(dirs, prop))
+    expected = str(Path("C:\\Users\\user\\AppData\\Local\\MyCompany\\MyApp\\Cache"))
+
+    assert result.replace("\\", "/") == expected.replace("\\", "/")

--- a/tests/test_user_cache_dir.py
+++ b/tests/test_user_cache_dir.py
@@ -16,6 +16,7 @@ def test_temp_env_vars_defined_and_ordered() -> None:
     """Ensure the canonical set of temp env vars stays intact"""
     assert TEMP_ENV_VARS == ("TMPDIR", "TEMPDIR", "TEMP", "TMP")
 
+
 @pytest.mark.parametrize("prop", ["user_cache_dir", "user_cache_path"])
 def test_user_cache_dir_linux_xdg_home_set(monkeypatch: MonkeyPatch, prop: str) -> None:
     """Test the user cache directory on Linux when XDG_CACHE_HOME is set."""


### PR DESCRIPTION
This change modifies `user_cache_dir` to respect temporary directory environment variables (`TMPDIR`, `TEMPDIR`, `TEMP`, `TMP`) as a configurable override for the cache location.

The hierarchy for determining the cache directory is now:
1. Platform-specific cache env vars (e.g., `XDG_CACHE_HOME`)
2. Temporary directory env vars (e.g., `TMPDIR`)
3. Platform-specific default locations

This provides a consistent and configurable behavior across all platforms, while prioritizing cache-specific settings where available. Closes #347 