### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,7 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - "pypy3.10" # ahead to start it earlier because takes longer
+          - "pypy3.11" # ahead to start it earlier because takes longer
+          - "3.14"
           - "3.13"
           - "3.12"
           - "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries :: Python Modules",
@@ -96,12 +97,13 @@ installer = "uv"
 description = "Run the test suite"
 matrix = [
   { python = [
+    "3.14",
     "3.13",
     "3.12",
     "3.11",
     "3.10",
     "3.9",
-    "pypy3.10",
+    "pypy3.11",
   ] },
 ]
 features = [
@@ -242,7 +244,7 @@ count = true
 quiet-level = 3
 
 [tool.pyproject-fmt]
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.coverage]
 html.show_contexts = true


### PR DESCRIPTION
Also test PyPy3.11 instead of 3.10, because the latest PyPy releases only have that version:

https://pypy.org/posts/2025/07/pypy-v7320-release.html

And Python 3.9 will be EOL in a few weeks, could drop it now?

https://devguide.python.org/versions/