### PR TITLE
🔧 build: migrate from hatch to tox with ty

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -20,16 +20,18 @@ jobs:
       fail-fast: false
       matrix:
         py:
-          - "pypy3.11" # ahead to start it earlier because takes longer
+          - "pypy3.11"
           - "3.14"
           - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"
         os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+          - ubuntu-24.04
+          - windows-2025
+          - macos-15
+        exclude:
+          - { os: windows-2025, py: pypy3.11 }
 
     steps:
       - uses: actions/checkout@v6
@@ -37,120 +39,104 @@ jobs:
           fetch-depth: 0
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add .local/bin to Windows PATH
-        if: runner.os == 'Windows'
-        shell: bash
-        run: echo "$USERPROFILE/.local/bin" >> $GITHUB_PATH
-      - name: install hatch
-        run: uv tool install --python-preference only-managed --python 3.13 hatch
-      - name: install Python
+      - name: Install tox
+        run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
+      - name: Install Python
         run: uv python install --python-preference only-managed ${{ matrix.py }}
-      - name: Pick environment to run
-        run: |
-          import codecs; import os
-          py = "${{ matrix.py }}"
-          py = "test.{}".format(py if py.startswith("pypy") else f"py{py}")
-          print(f"Picked {py}")
-          with codecs.open(os.environ["GITHUB_ENV"], mode="a", encoding="utf-8") as file_handler:
-              file_handler.write(f"FORCE_COLOR=1\nENV={py}\n")
-        shell: python
-      - name: Setup test environment
-        run: |
-          hatch -v env create ${ENV}
-          hatch run ${ENV}:uv pip tree
-        shell: bash
+      - name: Setup test suite
+        run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
       - name: Run test suite
-        run: hatch -v run ${ENV}:run
+        run: |
+          if [[ "${{ matrix.py }}" == pypy* ]]; then
+            tox run --skip-pkg-install -e ${{ matrix.py }} --
+          else
+            tox run --skip-pkg-install -e ${{ matrix.py }}
+          fi
+        shell: bash
         env:
           PYTEST_ADDOPTS: "-vv --durations=20"
-          CI_RUN: "yes"
-        shell: bash
+          UV_PYTHON_PREFERENCE: only-managed
+          DIFF_AGAINST: HEAD
       - name: Rename coverage report file
+        if: ${{ !startsWith(matrix.py, 'pypy')}}
         run: |
-          import os; import sys;
-          os.rename(f"report{os.sep}.coverage.${{ matrix.py }}", f"report{os.sep}.coverage.${{ matrix.py }}-{sys.platform}")
+          import os; import sys
+          os.rename(f".tox/.coverage.${{ matrix.py }}", f".tox/.coverage.${{ matrix.py }}-{sys.platform}")
         shell: python
       - name: Upload coverage data
+        if: ${{ !startsWith(matrix.py, 'pypy')}}
         uses: actions/upload-artifact@v6
         with:
           include-hidden-files: true
-          name: coverage-${{ matrix.os }}-${{ matrix.py }}
-          path: "report/.coverage.*"
+          name: .coverage.${{ matrix.os }}.${{ matrix.py }}
+          path: ".tox/.coverage.*"
           retention-days: 3
 
   coverage:
     name: Combine coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: test
     steps:
-      - name: Let us have colors
-        run: echo "FORCE_COLOR=true" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: install hatch
-        run: uv tool install --python-preference only-managed --python 3.13 hatch
+      - name: Install tox
+        run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
+      - name: Build package to generate version
+        run: uv build --python 3.14 --python-preference only-managed --wheel . --out-dir dist
       - name: Setup coverage tool
-        run: |
-          hatch -v env create coverage
-          hatch run coverage:pip freeze
+        run: tox -e coverage --notest
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
       - name: Download coverage data
         uses: actions/download-artifact@v7
         with:
-          path: report
-          pattern: coverage-*
+          path: .tox
+          pattern: .coverage.*
           merge-multiple: true
       - name: Combine and report coverage
-        run: hatch run coverage:run
+        run: tox -e coverage --skip-pkg-install
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
       - name: Upload HTML report
         uses: actions/upload-artifact@v6
         with:
           name: html-report
-          path: report/html
+          path: .tox/htmlcov
 
   check:
-    name: ${{ matrix.env.name }} - ${{ matrix.os }}
+    name: ${{ matrix.tox_env }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
-        env:
-          - { "name": "default", "target": "show" }
-          - { "name": "type", "target": "run" }
-          - { "name": "docs", "target": "build" }
-          - { "name": "readme", "target": "run" }
+          - ubuntu-24.04
+          - windows-2025
+        tox_env:
+          - dev
+          - type
+          - docs
+          - pkg_meta
+        exclude:
+          - { os: windows-2025, tox_env: pkg_meta }
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add .local/bin to Windows PATH
-        if: runner.os == 'Windows'
-        shell: bash
-        run: echo "$USERPROFILE/.local/bin" >> $GITHUB_PATH
-      - name: install hatch
-        run: uv tool install --python-preference only-managed --python 3.13 hatch
-      - name: Setup ${{ matrix.env.name }}
-        run: |
-          hatch -v env create ${{ matrix.env.name }}
-          hatch run ${{ matrix.env.name }}:pip freeze
-      - name: Run ${{ matrix.env.name }}
-        run: hatch -v run ${{ matrix.env.name }}:${{ matrix.env.target }}
+      - name: Install tox
+        run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
+      - name: Setup test suite
+        run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.tox_env }}
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
+      - name: Run test suite
+        run: tox run --skip-pkg-install -e ${{ matrix.tox_env }}
+        env:
+          UV_PYTHON_PREFERENCE: only-managed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build package
-        run: uv build --python 3.13 --python-preference only-managed --sdist --wheel . --out-dir dist
+        run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
       - name: Store the distribution packages
         uses: actions/upload-artifact@v6
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,16 +13,20 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        additional_dependencies: ["tomli>=2.2.1"]
+        additional_dependencies: ["tomli>=2.4"]
+  - repo: https://github.com/tox-dev/tox-toml-fmt
+    rev: "v1.5.4"
+    hooks:
+      - id: tox-toml-fmt
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.12.1"
+    rev: "v2.15.3"
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.14.14"
+    rev: "v0.15.0"
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: "v3.8.1"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,10 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: "3"
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-sphinx:
-  builder: html
-  configuration: docs/conf.py
-  fail_on_warning: true
+  commands:
+    - pip install uv
+    - uv venv
+    - uv pip install tox-uv
+    - .venv/bin/tox run -e docs --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,161 +44,61 @@ classifiers = [
 dynamic = [
   "version",
 ]
-optional-dependencies.docs = [
-  "furo>=2025.9.25",
-  "proselint>=0.14",
-  "sphinx>=8.2.3",
-  "sphinx-autodoc-typehints>=3.2",
-]
-optional-dependencies.test = [
-  "appdirs==1.4.4",
-  "covdefaults>=2.3",
-  "pytest>=8.4.2",
-  "pytest-cov>=7",
-  "pytest-mock>=3.15.1",
-]
-optional-dependencies.type = [
-  "mypy>=1.18.2",
-]
-
 urls.Changelog = "https://github.com/tox-dev/platformdirs/releases"
 urls.Documentation = "https://platformdirs.readthedocs.io"
 urls.Homepage = "https://github.com/tox-dev/platformdirs"
 urls.Source = "https://github.com/tox-dev/platformdirs"
 urls.Tracker = "https://github.com/tox-dev/platformdirs/issues"
 
+[dependency-groups]
+dev = [
+  { include-group = "coverage" },
+  { include-group = "docs" },
+  { include-group = "fix" },
+  { include-group = "pkg-meta" },
+  { include-group = "test" },
+  { include-group = "type" },
+]
+test = [
+  "appdirs==1.4.4",
+  "covdefaults>=2.3",
+  "diff-cover>=10.2",
+  "pytest>=8.4.2",
+  "pytest-cov>=7",
+  "pytest-mock>=3.15.1",
+]
+type = [
+  "ty>=0.0.16",
+  { include-group = "test" },
+]
+docs = [
+  "furo>=2025.9.25",
+  "proselint>=0.14",
+  "sphinx>=8.2.3",
+  "sphinx-autodoc-typehints>=3.2",
+]
+coverage = [
+  "covdefaults>=2.3",
+  "coverage[toml]>=7.6.1",
+  "diff-cover>=10.2",
+]
+fix = [
+  "pre-commit-uv>=4.2",
+]
+pkg-meta = [
+  "check-wheel-contents>=0.6.3",
+  "twine>=6.2",
+  "uv>=0.10.2",
+]
+
 [tool.hatch]
 build.hooks.vcs.version-file = "src/platformdirs/version.py"
 build.targets.sdist.include = [
   "/src",
   "/tests",
-  "/tox.ini",
+  "/tox.toml",
 ]
 version.source = "vcs"
-
-[tool.hatch.envs.coverage]
-template = "coverage"
-installer = "uv"
-description = "combine coverage files and generate diff"
-dependencies = [
-  "covdefaults>=2.3",
-  "coverage[toml]>=7.6.1",
-  "diff-cover>=9.2",
-]
-env-vars = { COVERAGE_FILE = "report/.coverage" }
-[tool.hatch.envs.coverage.scripts]
-run = [
-  "coverage combine report",
-  "coverage report --skip-covered --show-missing",
-  "coverage xml -o report/coverage.xml",
-  "coverage html -d report/html",
-  "diff-cover --compare-branch {env:DIFF_AGAINST:origin/main} report/coverage.xml",
-]
-
-[tool.hatch.envs.default]
-installer = "uv"
-description = "Development environment"
-features = [
-  "test",
-  "docs",
-  "type",
-]
-scripts = { show = [
-  "uv pip tree",
-  'python -c "import sys; print(sys.executable)"',
-] }
-
-[tool.hatch.envs.docs]
-template = "docs"
-installer = "uv"
-description = "Build documentation using Sphinx"
-python = "3.12"
-dev-mode = false
-features = [
-  "docs",
-]
-[tool.hatch.envs.docs.scripts]
-build = [
-  """python -c "import glob; import subprocess; subprocess.call(['proselint'] + glob.glob('docs/*.rst'))" """,
-  """python -c "from shutil import rmtree; rmtree('docs/build', ignore_errors=True)" """,
-  "sphinx-build -d docs/build/tree docs docs/build --color -b html",
-  """python -c "from pathlib import Path; p=(Path('docs')/'build'/'index.html').absolute().as_uri(); print('Documentation built under '+p)" """,
-]
-
-[tool.hatch.envs.fix]
-template = "fix"
-installer = "uv"
-description = "Run the pre-commit tool to lint and autofix issues"
-python = "3.12"
-detached = true
-dependencies = [
-  "pre-commit-uv>=4.1",
-]
-scripts = { "run" = [
-  "pre-commit run --all-files --show-diff-on-failure",
-] }
-
-[tool.hatch.envs.readme]
-template = "readme"
-installer = "uv"
-description = "check that the long description is valid"
-python = "3.12"
-dependencies = [
-  "build[uv]>=1.2.2",
-  "twine>=5.1.1",
-  "check-wheel-contents>=0.6",
-]
-scripts = { "run" = [
-  "pyproject-build --installer uv -o dist",
-  "twine check dist/*.whl dist/*.tar.gz",
-  "check-wheel-contents dist",
-] }
-
-[tool.hatch.envs.test]
-template = "test"
-installer = "uv"
-# dev-mode = false # cannot enable this until https://github.com/pypa/hatch/issues/1237
-description = "Run the test suite"
-matrix = [
-  { python = [
-    "3.14",
-    "3.13",
-    "3.12",
-    "3.11",
-    "3.10",
-    "pypy3.11",
-  ] },
-]
-features = [
-  "test",
-]
-env-vars.COVERAGE_FILE = "report/.coverage.{matrix:python}"
-env-vars.COVERAGE_PROCESS_START = "pyproject.toml"
-env-vars._COVERAGE_SRC = "src/platformdirs"
-[tool.hatch.envs.test.scripts]
-run = [
-  """
-    pytest --junitxml report/junit.{matrix:python}.xml --cov src/platformdirs --cov tests \
-      --cov-config=pyproject.toml --no-cov-on-fail --cov-report term-missing:skip-covered --cov-context=test \
-      --cov-report html:report/html{matrix:python} --cov-report xml:report/coverage{matrix:python}.xml \
-      tests
-""",
-]
-
-[tool.hatch.envs.type]
-template = "type"
-installer = "uv"
-description = "Run the type checker"
-python = "3.12"
-dev-mode = false
-features = [
-  "type",
-  "test",
-]
-scripts = { run = [
-  "mypy --strict src",
-  "mypy --strict tests",
-] }
 
 [tool.ruff]
 line-length = 120
@@ -214,7 +114,6 @@ lint.ignore = [
   "D212",   # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible
   "D301",   # Use `r"""` if any backslashes in a docstring
   "D401",   # The first line of docstring should be in imperative mood
-
   "DOC",    # no support for restructuredtext
   "RUF067", # `__init__` module should only contain docstrings and re-exports
   "S104",   # Possible binding to all interfaces
@@ -229,7 +128,6 @@ lint.per-file-ignores."tests/**/*.py" = [
   "S101",    # asserts allowed in tests
   "S603",    # `subprocess` call: check for execution of untrusted input
 ]
-
 lint.isort = { known-first-party = [
   "platformdirs",
   "tests",
@@ -247,26 +145,25 @@ quiet-level = 3
 max_supported_python = "3.14"
 
 [tool.coverage]
-html.show_contexts = true
-html.skip_covered = false
-run.relative_files = true
-paths.source = [
-  "src",
-  "**/site-packages",
-]
-report.fail_under = 76
 run.parallel = true
 run.plugins = [
   "covdefaults",
 ]
-
-[tool.mypy]
-python_version = "3.11"
-show_error_codes = true
-strict = true
-overrides = [
-  { module = [
-    "appdirs.*",
-    "jnius.*",
-  ], ignore_missing_imports = true },
+paths.other = [
+  ".",
+  "*/platformdirs",
+  "*\\platformdirs",
 ]
+paths.source = [
+  "src",
+  ".tox/*/lib/*/site-packages",
+  ".tox\\*\\Lib\\site-packages",
+  "**/src",
+  "**\\src",
+]
+report.fail_under = 76
+html.show_contexts = true
+html.skip_covered = false
+
+[tool.ty]
+environment.python-version = "3.14"

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -135,7 +135,7 @@ def _android_folder() -> str | None:  # noqa: C901
         try:
             # ...and fall back to using plain pyjnius, if python4android isn't available or doesn't deliver any useful
             # result...
-            from jnius import autoclass  # noqa: PLC0415
+            from jnius import autoclass  # noqa: PLC0415  # ty: ignore[unresolved-import]
 
             context = autoclass("android.content.Context")
             result = context.getFilesDir().getParentFile().getAbsolutePath()
@@ -169,7 +169,7 @@ def _android_documents_folder() -> str:
     """:return: documents folder for the Android OS"""
     # Get directories with pyjnius
     try:
-        from jnius import autoclass  # noqa: PLC0415
+        from jnius import autoclass  # noqa: PLC0415  # ty: ignore[unresolved-import]
 
         context = autoclass("android.content.Context")
         environment = autoclass("android.os.Environment")
@@ -185,7 +185,7 @@ def _android_downloads_folder() -> str:
     """:return: downloads folder for the Android OS"""
     # Get directories with pyjnius
     try:
-        from jnius import autoclass  # noqa: PLC0415
+        from jnius import autoclass  # noqa: PLC0415  # ty: ignore[unresolved-import]
 
         context = autoclass("android.content.Context")
         environment = autoclass("android.os.Environment")
@@ -201,7 +201,7 @@ def _android_pictures_folder() -> str:
     """:return: pictures folder for the Android OS"""
     # Get directories with pyjnius
     try:
-        from jnius import autoclass  # noqa: PLC0415
+        from jnius import autoclass  # noqa: PLC0415  # ty: ignore[unresolved-import]
 
         context = autoclass("android.content.Context")
         environment = autoclass("android.os.Environment")
@@ -217,7 +217,7 @@ def _android_videos_folder() -> str:
     """:return: videos folder for the Android OS"""
     # Get directories with pyjnius
     try:
-        from jnius import autoclass  # noqa: PLC0415
+        from jnius import autoclass  # noqa: PLC0415  # ty: ignore[unresolved-import]
 
         context = autoclass("android.content.Context")
         environment = autoclass("android.os.Environment")
@@ -233,7 +233,7 @@ def _android_music_folder() -> str:
     """:return: music folder for the Android OS"""
     # Get directories with pyjnius
     try:
-        from jnius import autoclass  # noqa: PLC0415
+        from jnius import autoclass  # noqa: PLC0415  # ty: ignore[unresolved-import]
 
         context = autoclass("android.content.Context")
         environment = autoclass("android.os.Environment")

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -76,7 +76,7 @@ def test_android_folder_from_jnius(mocker: MockerFixture, monkeypatch: pytest.Mo
 
     _android_folder.cache_clear()
 
-    if PlatformDirs is Android:  # type: ignore[comparison-overlap] # See https://github.com/platformdirs/platformdirs/pull/295
+    if PlatformDirs is Android:
         import jnius  # pragma: no cover # noqa: PLC0415
 
         autoclass = mocker.spy(jnius, "autoclass")  # pragma: no cover

--- a/tox.toml
+++ b/tox.toml
@@ -1,0 +1,152 @@
+requires = [ "tox>=4.34.1" ]
+env_list = [ "fix", "3.14", "3.13", "3.12", "3.11", "3.10", "pypy3.11", "coverage", "type", "docs", "pkg_meta" ]
+skip_missing_interpreters = true
+
+[env_run_base]
+description = "run the tests with pytest under {env_name}"
+package = "wheel"
+wheel_build_env = ".pkg"
+dependency_groups = [ "test" ]
+pass_env = [ "PYTEST_*", "SSL_CERT_FILE" ]
+set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage.{env_name}" }
+commands = [
+  [
+    "pytest",
+    "--durations",
+    "10",
+    "--junitxml",
+    "{env_tmp_dir}{/}junit.xml",
+    { replace = "posargs", extend = true, default = [
+      "--no-cov-on-fail",
+      "--cov",
+      "{env_site_packages_dir}{/}platformdirs",
+      "--cov",
+      "{tox_root}{/}tests",
+      "--cov-config",
+      "{tox_root}{/}pyproject.toml",
+      "--cov-context",
+      "test",
+      "--cov-report",
+      "term-missing:skip-covered",
+      "--cov-report",
+      "html:{env_tmp_dir}{/}htmlcov",
+      "--cov-report",
+      "xml:{env_tmp_dir}{/}coverage.xml",
+    ] },
+    "tests",
+  ],
+  { replace = "posargs", extend = true, default = [
+    [
+      "diff-cover",
+      "--compare-branch",
+      { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+      "{env_tmp_dir}{/}coverage.xml",
+    ],
+  ] },
+]
+
+[env.fix]
+description = "format the code base to adhere to our styles, and complain about what we cannot do automatically"
+skip_install = true
+dependency_groups = [ "fix" ]
+pass_env = [
+  { replace = "ref", of = [
+    "env_run_base",
+    "pass_env",
+  ], extend = true },
+  "PROGRAMDATA",
+  "DISABLE_PRE_COMMIT_UV_PATCH",
+]
+commands = [ [ "pre-commit", "run", "--all-files", "--show-diff-on-failure", { replace = "posargs", extend = true } ] ]
+
+[env.coverage]
+description = "combine coverage files and generate diff (against DIFF_AGAINST defaulting to origin/main)"
+skip_install = true
+dependency_groups = [ "coverage" ]
+pass_env = [
+  { replace = "ref", of = [
+    "env_run_base",
+    "pass_env",
+  ], extend = true },
+  "DIFF_AGAINST",
+]
+set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage" }
+commands = [
+  [ "coverage", "combine" ],
+  [ "coverage", "report", "--skip-covered", "--show-missing" ],
+  [ "coverage", "xml", "-o", "{env_tmp_dir}{/}coverage.xml" ],
+  [ "coverage", "html", "-d", "{work_dir}{/}htmlcov" ],
+  [
+    "diff-cover",
+    "--compare-branch",
+    { replace = "env", name = "DIFF_AGAINST", default = "origin/main" },
+    "{env_tmp_dir}{/}coverage.xml",
+  ],
+]
+parallel_show_output = true
+depends = [ "3.14", "3.13", "3.12", "3.11", "3.10", "pypy3.11" ]
+
+[env.type]
+description = "run type check on code base"
+dependency_groups = [ "type" ]
+commands = [ [ "ty", "check", "--output-format", "concise", "--error-on-warning", "." ] ]
+
+[env.docs]
+description = "build documentation"
+dependency_groups = [ "docs" ]
+commands = [
+  [
+    "python",
+    "-c",
+    "import glob; import subprocess; subprocess.call(['proselint'] + glob.glob('docs/*.rst'))",
+  ],
+  [
+    "sphinx-build",
+    "-d",
+    "{env_tmp_dir}{/}docs_tree",
+    "docs",
+    "{env:READTHEDOCS_OUTPUT:{work_dir}{/}docs_out}/html",
+    "--color",
+    "-b",
+    "html",
+    { replace = "posargs", default = [], extend = true },
+    "-W",
+  ],
+  [
+    "python",
+    "-c",
+    'print(r"documentation available under file://{work_dir}{/}docs_out{/}html{/}index.html")',
+  ],
+]
+
+[env.pkg_meta]
+description = "check that the long description is valid"
+skip_install = true
+dependency_groups = [ "pkg-meta" ]
+commands = [
+  [
+    "uv",
+    "build",
+    "--sdist",
+    "--wheel",
+    "--out-dir",
+    "{env_tmp_dir}",
+    ".",
+  ],
+  [
+    "twine",
+    "check",
+    "{env_tmp_dir}{/}*",
+  ],
+  [
+    "check-wheel-contents",
+    "--no-config",
+    "{env_tmp_dir}",
+  ],
+]
+
+[env.dev]
+description = "dev environment with all deps at {envdir}"
+package = "editable"
+dependency_groups = [ "dev" ]
+commands = [ [ "uv", "pip", "list", "--format=columns" ], [ "python", "-c", 'print(r"{env_python}")' ] ]


### PR DESCRIPTION
The platformdirs project was the last tox-dev project still using hatch for environment management. 🔧 Migrating to tox aligns it with the rest of the ecosystem (filelock, tox, etc.) and brings consistency to how all tox-dev projects are developed and tested.

This replaces hatch environments with a `tox.toml` configuration covering test, fix, coverage, type checking, docs, package metadata validation, and dev environments. The `optional-dependencies` sections move to PEP 735 `dependency-groups`, and `mypy` is replaced by `ty` for type checking. CI workflows now install `tox` + `tox-uv` instead of `hatch`, ReadTheDocs builds docs through tox, and `tox-toml-fmt` is added to pre-commit.

Coverage path mappings are updated for tox's `.tox/` layout. The release workflow bumps to Python 3.14. All existing functionality (multi-version testing, coverage aggregation, docs, linting) is preserved under the new runner.