### PR TITLE
📝 docs: restructure docs and fix cross-references

### DIFF
--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -1,6 +1,9 @@
 """
 Utilities for determining application-specific dirs.
 
+Provides convenience functions (e.g. :func:`user_data_dir`, :func:`user_config_path`), a :data:`PlatformDirs` class
+that auto-detects the current platform, and the :class:`~platformdirs.api.PlatformDirsABC` base class.
+
 See <https://github.com/platformdirs/platformdirs> for details and usage.
 
 """
@@ -85,7 +88,7 @@ def site_data_dir(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: data directory shared by users
     """
@@ -133,7 +136,7 @@ def site_config_dir(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: config directory shared by users
     """
@@ -157,7 +160,7 @@ def user_cache_dir(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: cache directory tied to the user
     """
@@ -229,7 +232,7 @@ def user_log_dir(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: log directory tied to the user
     """
@@ -403,7 +406,7 @@ def site_config_path(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param multipath: See `roaming <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: config path shared by users
     """
@@ -429,7 +432,7 @@ def site_cache_path(
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
     :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
-    :returns: cache directory shared by users
+    :returns: cache path shared by users
     """
     return PlatformDirs(
         appname=appname,
@@ -451,7 +454,7 @@ def user_cache_path(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: cache path tied to the user
     """
@@ -499,7 +502,7 @@ def user_log_path(
     :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param opinion: See `roaming <platformdirs.api.PlatformDirsABC.opinion>`.
+    :param opinion: See `opinion <platformdirs.api.PlatformDirsABC.opinion>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
     :returns: log path tied to the user
     """
@@ -513,7 +516,7 @@ def user_log_path(
 
 
 def user_documents_path() -> Path:
-    """:returns: documents a path tied to the user"""
+    """:returns: documents path tied to the user"""
     return PlatformDirs().user_documents_path
 
 

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -13,10 +13,14 @@ from .api import PlatformDirsABC
 
 class Android(PlatformDirsABC):
     """
-    Follows the guidance `from here <https://android.stackexchange.com/a/216132>`_.
+    Platform directories for Android.
+
+    Follows the guidance `from here <https://android.stackexchange.com/a/216132>`_. Directories are typically located
+    under the app's private storage (``/data/user/<userid>/<packagename>/``).
 
     Makes use of the `appname <platformdirs.api.PlatformDirsABC.appname>`, `version
-    <platformdirs.api.PlatformDirsABC.version>`, `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    <platformdirs.api.PlatformDirsABC.version>`, `opinion <platformdirs.api.PlatformDirsABC.opinion>`,
+    `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
 
     """
 

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -13,7 +13,15 @@ if TYPE_CHECKING:
 
 
 class PlatformDirsABC(ABC):  # noqa: PLR0904
-    """Abstract base class for platform directories."""
+    """
+    Abstract base class defining all platform directory properties, their :class:`~pathlib.Path` variants, and
+    iterators.
+
+    Platform-specific subclasses (e.g. :class:`~platformdirs.windows.Windows`,
+    :class:`~platformdirs.macos.MacOS`, :class:`~platformdirs.unix.Unix`) implement the abstract
+    properties to return the appropriate paths for each operating system.
+
+    """
 
     def __init__(  # noqa: PLR0913, PLR0917
         self,
@@ -37,7 +45,7 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
         :param ensure_exists: See `ensure_exists`.
 
         """
-        self.appname = appname  #: The name of application.
+        self.appname = appname  #: The name of the application.
         self.appauthor = appauthor
         """
         The name of the app author or distributing body for this application.
@@ -66,10 +74,18 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
         """
         An optional parameter which indicates that the entire list of data dirs should be returned.
 
-        By default, the first item would only be returned.
+        By default, the first item would only be returned. Only affects ``site_data_dir`` and ``site_config_dir`` on
+        Unix and macOS.
 
         """
-        self.opinion = opinion  #: A flag to indicating to use opinionated values.
+        self.opinion = opinion
+        """
+        Whether to use opinionated values.
+
+        When enabled, appends an additional subdirectory for certain directories: e.g. ``Cache`` for cache and ``Logs``
+        for logs on Windows, ``log`` for logs on Unix.
+
+        """
         self.ensure_exists = ensure_exists
         """
         Optionally create the directory (and any missing parents) upon access if it does not exist.
@@ -220,7 +236,7 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
 
     @property
     def user_documents_path(self) -> Path:
-        """:return: documents a path tied to the user"""
+        """:return: documents path tied to the user"""
         return Path(self.user_documents_dir)
 
     @property

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -15,11 +15,11 @@ if TYPE_CHECKING:
 
 class _MacOSDefaults(PlatformDirsABC):
     """
-    Default platform directories for macOS.
+    Default platform directories for macOS without XDG environment variable overrides.
 
     Follows the guidance from
-    `Apple documentation <https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html>`_.
-    The XDG env var handling is in :class:`~platformdirs.xdg.XDGMixin`.
+    `Apple's File System Programming Guide <https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html>`_.
+    The XDG env var handling is in :class:`~platformdirs._xdg.XDGMixin`.
     """
 
     @property

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -28,7 +28,7 @@ class _UnixDefaults(PlatformDirsABC):
     """
     Default directories for Unix/Linux without XDG environment variable overrides.
 
-    The XDG env var handling is in :class:`~platformdirs.xdg.XDGMixin`.
+    The XDG env var handling is in :class:`~platformdirs._xdg.XDGMixin`.
     """
 
     @property
@@ -59,7 +59,7 @@ class _UnixDefaults(PlatformDirsABC):
     def user_cache_dir(self) -> str:
         """
         :return: cache directory tied to the user, e.g. ``~/.cache/$appname/$version`` or
-         ``~/$XDG_CACHE_HOME/$appname/$version``
+         ``$XDG_CACHE_HOME/$appname/$version``
         """
         return self._append_app_name_and_version(os.path.expanduser("~/.cache"))  # noqa: PTH111
 

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -256,6 +256,7 @@ def get_win_folder_via_ctypes(csidl_name: str) -> str:
 
 
 def _pick_get_win_folder() -> Callable[[str], str]:
+    """Select the best method to resolve Windows folder paths: ctypes, then registry, then environment variables."""
     try:
         import ctypes  # noqa: PLC0415
     except ImportError:


### PR DESCRIPTION
The README was a monolithic RST file containing full output examples for every platform, making it hard to scan. The Sphinx docs consisted of a single `api.rst` page with a sparse index, and several API entries (`user_desktop_dir`/`user_desktop_path`, `site_runtime_dir`/`site_runtime_path`) were missing entirely. The docstrings also had broken cross-references (e.g. `:param multipath: See roaming`) and stale wording.

This replaces `README.rst` with a lean `README.md` focused on a quick-start example and links to readthedocs. The Sphinx docs are split into three pages: a usage guide covering all parameters with examples, a complete API reference, and a platform details page with a comparison table of default paths across macOS/Windows/Linux/Android. Each platform section includes the `autoclass` directive so the class docs render inline with the platform context.

`CONTRIBUTING.md` now references `tox` instead of `hatch` (which was already migrated in #415), the `proselint` invocation in `tox.toml` is updated for its new `check` subcommand CLI, and `pyproject.toml` points to the new `README.md`.