### PR TITLE
✨ feat(windows): add PLATFORMDIRS_* env var overrides

### DIFF
--- a/docs/platforms.rst
+++ b/docs/platforms.rst
@@ -313,6 +313,56 @@ Key behaviors:
   which syncs across machines in a Windows domain
 - **OPINION**: ``user_cache_dir`` appends ``\Cache``, ``user_log_dir`` appends ``\Logs``
 
+Environment variable overrides
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unlike Linux/macOS where ``XDG_*`` variables are a platform standard, Windows has no built-in
+convention for overriding folder locations at the application level. To fill this gap,
+``platformdirs`` checks ``PLATFORMDIRS_*`` environment variables before querying the Shell Folder
+APIs. This is useful when large data (ML models, package caches) should live on a different drive
+without changing the system-wide ``APPDATA`` / ``LOCALAPPDATA`` variables that other applications
+rely on.
+
+The override variable name is ``PLATFORMDIRS_`` followed by the CSIDL suffix:
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - Environment variable
+     - Overrides
+   * - ``PLATFORMDIRS_APPDATA``
+     - Roaming user data (``AppData\Roaming``)
+   * - ``PLATFORMDIRS_LOCAL_APPDATA``
+     - Local user data, config, cache, state (``AppData\Local``)
+   * - ``PLATFORMDIRS_COMMON_APPDATA``
+     - Site-wide data, config, cache, state (``ProgramData``)
+   * - ``PLATFORMDIRS_PERSONAL``
+     - Documents
+   * - ``PLATFORMDIRS_DOWNLOADS``
+     - Downloads
+   * - ``PLATFORMDIRS_MYPICTURES``
+     - Pictures
+   * - ``PLATFORMDIRS_MYVIDEO``
+     - Videos
+   * - ``PLATFORMDIRS_MYMUSIC``
+     - Music
+   * - ``PLATFORMDIRS_DESKTOPDIRECTORY``
+     - Desktop
+
+Example — redirect cache to a separate drive:
+
+.. code-block:: python
+
+   import os
+   os.environ["PLATFORMDIRS_LOCAL_APPDATA"] = r"X:\appdata"
+
+   import platformdirs
+   print(platformdirs.user_cache_dir("MyApp", "Acme"))
+   # X:\appdata\Acme\MyApp\Cache
+
+Empty or whitespace-only values are ignored and the normal resolution applies.
+
 .. note:: **Windows Store Python (MSIX)**
 
    Python installed from the Microsoft Store runs in a sandboxed (AppContainer) environment.

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sys
-from functools import lru_cache
 from typing import TYPE_CHECKING, Final
 
 from .api import PlatformDirsABC
@@ -320,7 +319,21 @@ def _pick_get_win_folder() -> Callable[[str], str]:
         return get_win_folder_from_registry
 
 
-get_win_folder = lru_cache(maxsize=None)(_pick_get_win_folder())
+_resolve_win_folder = _pick_get_win_folder()
+
+
+def get_win_folder(csidl_name: str) -> str:
+    """
+    Get a Windows folder path, checking for ``PLATFORMDIRS_*`` environment variable overrides first.
+
+    For example, ``CSIDL_LOCAL_APPDATA`` can be overridden by setting ``PLATFORMDIRS_LOCAL_APPDATA``.
+
+    """
+    env_var = f"PLATFORMDIRS_{csidl_name.removeprefix('CSIDL_')}"
+    if override := os.environ.get(env_var, "").strip():
+        return override
+    return _resolve_win_folder(csidl_name)
+
 
 __all__ = [
     "Windows",


### PR DESCRIPTION
On Windows the Shell Folder APIs (ctypes/registry) provide no mechanism for users to redirect directories at runtime. This matters when large data — ML models, package caches, build artifacts — should live on a different drive without changing the system-wide `APPDATA` / `LOCALAPPDATA` variables that every other application relies on. On Linux/macOS `XDG_*` variables solve this naturally, but Windows has no equivalent convention. Fixes #347.

`get_win_folder` now checks for a `PLATFORMDIRS_*` environment variable (e.g. `PLATFORMDIRS_LOCAL_APPDATA`) before falling back to the existing resolution. The prefix avoids colliding with the real Windows variables while making the provenance obvious. The previous `lru_cache` on `get_win_folder` is removed so overrides are picked up dynamically at each access.

The platforms documentation now includes a full reference table of the nine supported override variables with an example showing how to redirect cache to a separate drive.