### PR TITLE
🐛 fix(macos): yield individual site dirs in iter_*_dirs

### DIFF
--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -6,6 +6,9 @@ import os.path
 import sys
 from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 from ._xdg import XDGMixin
 from .api import PlatformDirsABC
 
@@ -136,6 +139,16 @@ class _MacOSDefaults(PlatformDirsABC):
     def site_runtime_dir(self) -> str:
         """:return: runtime directory shared by users, same as `user_runtime_dir`"""
         return self.user_runtime_dir
+
+    def iter_config_dirs(self) -> Iterator[str]:
+        """:yield: all user and site configuration directories."""
+        yield self.user_config_dir
+        yield from self._site_config_dirs
+
+    def iter_data_dirs(self) -> Iterator[str]:
+        """:yield: all user and site data directories."""
+        yield self.user_data_dir
+        yield from self._site_data_dirs
 
 
 class MacOS(XDGMixin, _MacOSDefaults):


### PR DESCRIPTION
On macOS, `iter_data_dirs()` and `iter_config_dirs()` were falling back to the base class implementation which yields `site_data_dir` as a single string. When `XDG_DATA_DIRS` is set with multiple paths (common on NixOS and similar setups) or under Homebrew where multiple site directories exist, this produced a colon-joined string like `/path1:/path2` instead of yielding each directory individually. 🐛

The Unix platform already overrides both methods to `yield from self._site_data_dirs` / `self._site_config_dirs`, correctly producing individual paths. macOS has the same `_site_data_dirs` and `_site_config_dirs` properties (Homebrew-aware + XDG mixin) but was missing the matching overrides. This adds the identical overrides to `_MacOSDefaults`, consistent with the existing Unix approach.

Windows is unaffected since it only has single-value site directories with no `_site_data_dirs` property.

Fixes #377