### PR TITLE
✨ feat(api): add user_bin_dir property

### DIFF
--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -335,6 +335,11 @@ def user_desktop_dir() -> str:
     return PlatformDirs().user_desktop_dir
 
 
+def user_bin_dir() -> str:
+    """:returns: bin directory tied to the user"""
+    return PlatformDirs().user_bin_dir
+
+
 def user_runtime_dir(  # noqa: PLR0913, PLR0917
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
@@ -668,6 +673,11 @@ def user_desktop_path() -> Path:
     return PlatformDirs().user_desktop_path
 
 
+def user_bin_path() -> Path:
+    """:returns: bin path tied to the user"""
+    return PlatformDirs().user_bin_path
+
+
 def user_runtime_path(  # noqa: PLR0913, PLR0917
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
@@ -737,6 +747,8 @@ __all__ = [
     "site_runtime_path",
     "site_state_dir",
     "site_state_path",
+    "user_bin_dir",
+    "user_bin_path",
     "user_cache_dir",
     "user_cache_path",
     "user_config_dir",

--- a/src/platformdirs/__main__.py
+++ b/src/platformdirs/__main__.py
@@ -15,6 +15,7 @@ PROPS = (
     "user_pictures_dir",
     "user_videos_dir",
     "user_music_dir",
+    "user_bin_dir",
     "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",

--- a/src/platformdirs/android.py
+++ b/src/platformdirs/android.py
@@ -114,6 +114,11 @@ class Android(PlatformDirsABC):
         return "/storage/emulated/0/Desktop"
 
     @property
+    def user_bin_dir(self) -> str:
+        """:return: bin directory tied to the user, e.g. ``/data/user/<userid>/<packagename>/files/bin``"""
+        return os.path.join(cast("str", _android_folder()), "files", "bin")  # noqa: PTH118
+
+    @property
     def user_runtime_dir(self) -> str:
         """
         :return: runtime directory tied to the user, same as `user_cache_dir` if not opinionated else ``tmp`` in it,

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -206,6 +206,11 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
 
     @property
     @abstractmethod
+    def user_bin_dir(self) -> str:
+        """:return: bin directory tied to the user"""
+
+    @property
+    @abstractmethod
     def user_runtime_dir(self) -> str:
         """:return: runtime directory tied to the user"""
 
@@ -293,6 +298,11 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
     def user_desktop_path(self) -> Path:
         """:return: desktop path tied to the user"""
         return Path(self.user_desktop_dir)
+
+    @property
+    def user_bin_path(self) -> Path:
+        """:return: bin path tied to the user"""
+        return Path(self.user_bin_dir)
 
     @property
     def user_runtime_path(self) -> Path:

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-class _MacOSDefaults(PlatformDirsABC):
+class _MacOSDefaults(PlatformDirsABC):  # noqa: PLR0904
     """
     Default platform directories for macOS without XDG environment variable overrides.
 
@@ -129,6 +129,11 @@ class _MacOSDefaults(PlatformDirsABC):
     def user_desktop_dir(self) -> str:
         """:return: desktop directory tied to the user, e.g. ``~/Desktop``"""
         return os.path.expanduser("~/Desktop")  # noqa: PTH111
+
+    @property
+    def user_bin_dir(self) -> str:
+        """:return: bin directory tied to the user, e.g. ``~/.local/bin``"""
+        return os.path.expanduser("~/.local/bin")  # noqa: PTH111
 
     @property
     def user_runtime_dir(self) -> str:

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -136,6 +136,11 @@ class _UnixDefaults(PlatformDirsABC):  # noqa: PLR0904
         return _get_user_media_dir("XDG_DESKTOP_DIR", "~/Desktop")
 
     @property
+    def user_bin_dir(self) -> str:
+        """:return: bin directory tied to the user, e.g. ``~/.local/bin``"""
+        return os.path.expanduser("~/.local/bin")  # noqa: PTH111
+
+    @property
     def user_runtime_dir(self) -> str:
         """
         :return: runtime directory tied to the user, e.g. ``$XDG_RUNTIME_DIR/$appname/$version``.

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -142,6 +142,11 @@ class Windows(PlatformDirsABC):
         return os.path.normpath(get_win_folder("CSIDL_DESKTOPDIRECTORY"))
 
     @property
+    def user_bin_dir(self) -> str:
+        """:return: bin directory tied to the user, e.g. ``%LOCALAPPDATA%\\Programs``"""
+        return os.path.normpath(os.path.join(get_win_folder("CSIDL_LOCAL_APPDATA"), "Programs"))  # noqa: PTH118
+
+    @property
     def user_runtime_dir(self) -> str:
         """
         :return: runtime directory tied to the user, e.g.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ PROPS = (
     "user_pictures_dir",
     "user_videos_dir",
     "user_music_dir",
+    "user_bin_dir",
     "user_runtime_dir",
     "site_data_dir",
     "site_config_dir",

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -61,6 +61,7 @@ def test_android(mocker: MockerFixture, params: dict[str, Any], func: str) -> No
         "user_videos_dir": "/storage/emulated/0/DCIM/Camera",
         "user_music_dir": "/storage/emulated/0/Music",
         "user_desktop_dir": "/storage/emulated/0/Desktop",
+        "user_bin_dir": "/data/data/com.example/files/bin",
         "user_runtime_dir": f"/data/data/com.example/cache{suffix}{'' if not params.get('opinion', True) else val}",
         "site_runtime_dir": f"/data/data/com.example/cache{suffix}{'' if not params.get('opinion', True) else val}",
     }

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -83,6 +83,7 @@ def test_macos(mocker: MockerFixture, params: dict[str, Any], func: str) -> None
         "user_videos_dir": f"{home}/Movies",
         "user_music_dir": f"{home}/Music",
         "user_desktop_dir": f"{home}/Desktop",
+        "user_bin_dir": f"{home}/.local/bin",
         "user_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
         "site_runtime_dir": f"{home}/Library/Caches/TemporaryItems{suffix}",
     }
@@ -266,6 +267,7 @@ def test_macos_xdg_empty_falls_back(
         "user_videos_dir": f"{home}/Movies",
         "user_music_dir": f"{home}/Music",
         "user_desktop_dir": f"{home}/Desktop",
+        "user_bin_dir": f"{home}/.local/bin",
     }
     assert getattr(MacOS(), prop) == expected_map[prop]
 

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -105,6 +105,7 @@ def _func_to_path(func: str) -> XDGVariable | None:
         "user_state_dir": XDGVariable("XDG_STATE_HOME", "~/.local/state"),
         "user_log_dir": XDGVariable("XDG_STATE_HOME", "~/.local/state"),
         "user_runtime_dir": XDGVariable("XDG_RUNTIME_DIR", f"{gettempdir()}/runtime-1234"),
+        "user_bin_dir": None,
         "site_log_dir": None,
         "site_state_dir": None,
         "site_runtime_dir": XDGVariable("XDG_RUNTIME_DIR", "/run"),

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -88,6 +88,7 @@ def test_windows(params: dict[str, Any], func: str) -> None:
         "user_videos_dir": os.path.normpath(_WIN_FOLDERS["CSIDL_MYVIDEO"]),
         "user_music_dir": os.path.normpath(_WIN_FOLDERS["CSIDL_MYMUSIC"]),
         "user_desktop_dir": os.path.normpath(_WIN_FOLDERS["CSIDL_DESKTOPDIRECTORY"]),
+        "user_bin_dir": os.path.join(_LOCAL, "Programs"),  # noqa: PTH118
         "user_runtime_dir": temp,
         "site_runtime_dir": temp,
     }


### PR DESCRIPTION
Applications that install user-facing executables (CLI tools, helper scripts) need a platform-correct directory that's typically on PATH. Currently there's no way to ask platformdirs for this location, so every tool reinvents the logic. ✨ The new `user_bin_dir` and `user_bin_path` properties provide the standard answer per platform: `~/.local/bin` on Unix/macOS (per XDG spec and pip/pipx convention), `%LOCALAPPDATA%\Programs` on Windows (`FOLDERID_UserProgramFiles`), and `<android_folder>/files/bin` on Android.

Like other media directories (`user_documents_dir`, `user_downloads_dir`, etc.), `user_bin_dir` does not append `appname` or `version` since bin directories are shared across applications. No XDG environment variable override is provided because the XDG spec does not define one for this directory.

Closes #331