### PR TITLE
📝 docs(usage): note that home dir is in stdlib

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -151,6 +151,18 @@ Defaults to ``False``.
    dirs = PlatformDirs("SuperApp", "Acme", ensure_exists=True)
    dirs.user_cache_dir  # directory is created if it does not exist
 
+Directories not covered
+-----------------------
+
+``platformdirs`` does not provide a property for the user's **home directory**. Use
+:meth:`pathlib.Path.home` or :func:`os.path.expanduser` from the standard library instead:
+
+.. code-block:: pycon
+
+   >>> from pathlib import Path
+   >>> Path.home()
+   PosixPath('/Users/trentm')
+
 XDG environment variables
 -------------------------
 


### PR DESCRIPTION
Users periodically ask for a home directory property (#235). Rather than adding a wrapper around stdlib, this adds a "Directories not covered" section to the usage docs pointing to `pathlib.Path.home()` and `os.path.expanduser()` so the answer is discoverable without filing issues.

Partially addresses #235 (the home directory part only).