### PR TITLE
🐛 fix(unix): use correct runtime dir path for OpenBSD

### DIFF
--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -150,11 +150,13 @@ class _UnixDefaults(PlatformDirsABC):  # noqa: PLR0904
         """
         :return: runtime directory tied to the user, e.g. ``$XDG_RUNTIME_DIR/$appname/$version``.
 
-        If ``$XDG_RUNTIME_DIR`` is unset, tries the platform default (``/var/run/user/$(id -u)`` on
-        FreeBSD/OpenBSD/NetBSD, ``/run/user/$(id -u)`` otherwise). If the default is not writable,
-        falls back to a temporary directory.
+        If ``$XDG_RUNTIME_DIR`` is unset, tries the platform default (``/tmp/run/user/$(id -u)`` on
+        OpenBSD, ``/var/run/user/$(id -u)`` on FreeBSD/NetBSD, ``/run/user/$(id -u)`` otherwise).
+        If the default is not writable, falls back to a temporary directory.
         """
-        if sys.platform.startswith(("freebsd", "openbsd", "netbsd")):
+        if sys.platform.startswith("openbsd"):
+            path = f"/tmp/run/user/{getuid()}"  # noqa: S108
+        elif sys.platform.startswith(("freebsd", "netbsd")):
             path = f"/var/run/user/{getuid()}"
         else:
             path = f"/run/user/{getuid()}"


### PR DESCRIPTION
OpenBSD applications using platformdirs were unnecessarily falling back to temporary directories because the default runtime path `/var/run/user/{uid}` is not writable by regular users on OpenBSD. 🔒 This issue was reported by OpenBSD package maintainers who noticed the mismatch with the platform's native XDG implementation.

OpenBSD now has native `XDG_RUNTIME_DIR` support in libc via the `setxdgenv()` function in [`lib/libc/gen/login_cap.c`](https://github.com/openbsd/src/blob/master/lib/libc/gen/login_cap.c), which creates directories at `/tmp/run/user/{uid}` with proper ownership and permissions. The fix splits the BSD platform detection to handle OpenBSD separately from FreeBSD and NetBSD, which both continue using `/var/run/user/{uid}`. ✨

This change aligns platformdirs with OpenBSD's official implementation while preserving existing behavior for FreeBSD and NetBSD. Applications on OpenBSD will now correctly use the runtime directory created by the system during login instead of falling back to temporary directories.

## Documentation References

During investigation, the following official platform documentation was reviewed:

- **OpenBSD**: [`setxdgenv()` in login_cap.c](https://github.com/openbsd/src/blob/master/lib/libc/gen/login_cap.c) - uses `/tmp/run/user/{uid}`
- **FreeBSD**: [`pam_xdg` module](https://github.com/freebsd/freebsd-src/blob/main/lib/libpam/modules/pam_xdg/pam_xdg.c) - uses `/var/run/xdg/{username}` (platformdirs fallback of `/var/run/user/{uid}` is reasonable)
- **NetBSD**: No native XDG support found; [pkgsrc patches](https://github.com/NetBSD/pkgsrc/blob/trunk/misc/py-platformdirs/patches/patch-tests_test__unix.py) treat it same as FreeBSD

Fixes #436