### PR TITLE
📝 docs: add project logo to documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
         language: python
         types: [markdown]
         additional_dependencies:
-          - mdformat-gfm
-          - mdformat-ruff
+          - mdformat-gfm>=1
+          - mdformat-ruff>=0.1.3
   - repo: https://github.com/LilSpazJoekp/docstrfmt
     rev: v2.0.2
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ extensions = [
     "sphinxext.opengraph",
 ]
 html_theme = "furo"
+html_logo = html_favicon = "platformdirs.svg"
 html_title, html_last_updated_fmt = "platformdirs", datetime.now(tz=timezone.utc).isoformat()
 pygments_style, pygments_dark_style = "sphinx", "monokai"
 autoclass_content, autodoc_member_order, autodoc_typehints = "class", "bysource", "none"

--- a/docs/platformdirs.svg
+++ b/docs/platformdirs.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="platformdirs">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#306998"></rect>
+  <!-- notch (dir tab) -->
+  <path d="M18 18h14l4 5H18z" fill="#FFD43B"></path>
+  <!-- P -->
+  <path fill="#FFD43B" d="
+    M22 22h16c7 0 12 4.5 12 11.5S45 45 38 45H30v11H22V22zm8 7v9h7
+    c3.5 0 5.5-1.6 5.5-4.5S40.5 29 37 29h-7z
+  "></path>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs>=0.5",
-  "hatchling>=1.27",
+  "hatchling>=1.29",
 ]
 
 [project]
@@ -63,38 +63,38 @@ test = [
   "appdirs==1.4.4",
   "covdefaults>=2.3",
   "diff-cover>=10.2",
-  "pytest>=8.4.2",
+  "pytest>=9.0.2",
   "pytest-cov>=7",
   "pytest-mock>=3.15.1",
 ]
 type = [
-  "ty>=0.0.16",
+  "ty>=0.0.19",
   { include-group = "release" },
   { include-group = "test" },
 ]
 docs = [
-  "furo>=2025.9.25",
-  "proselint>=0.14",
-  "sphinx>=8.2.3",
-  "sphinx-autodoc-typehints>=3.2",
+  "furo>=2025.12.19",
+  "proselint>=0.16",
+  "sphinx>=9.1",
+  "sphinx-autodoc-typehints>=3.9.2",
   "sphinx-copybutton>=0.5.2",
-  "sphinx-design>=0.6.1",
-  "sphinx-sitemap>=2.6",
-  "sphinxcontrib-mermaid>=0.9.5",
-  "sphinxext-opengraph>=0.10.2",
+  "sphinx-design>=0.7",
+  "sphinx-sitemap>=2.9",
+  "sphinxcontrib-mermaid>=2",
+  "sphinxext-opengraph>=0.13",
 ]
 coverage = [
   "covdefaults>=2.3",
-  "coverage[toml]>=7.6.1",
+  "coverage[toml]>=7.13.4",
   "diff-cover>=10.2",
 ]
 fix = [
-  "pre-commit-uv>=4.2",
+  "pre-commit-uv>=4.2.1",
 ]
 pkg-meta = [
   "check-wheel-contents>=0.6.3",
   "twine>=6.2",
-  "uv>=0.10.2",
+  "uv>=0.10.7",
 ]
 release = [
   "gitpython>=3.1.46",

--- a/tox.toml
+++ b/tox.toml
@@ -1,4 +1,4 @@
-requires = [ "tox>=4.34.1" ]
+requires = [ "tox>=4.47" ]
 env_list = [ "3.14", "3.13", "3.12", "3.11", "3.10", "pypy3.11", "coverage", "docs", "fix", "pkg_meta", "type" ]
 skip_missing_interpreters = true
 


### PR DESCRIPTION
The documentation currently has no visual branding, making it harder to recognize at a glance. Adding a logo to the sidebar gives the docs a distinct identity and a more polished appearance. 🎨

The SVG logo features a folder-tab motif with the letter "P" in Python's signature blue and yellow palette, tying the project's identity to its Python roots. Furo's `html_logo` configuration picks it up automatically and renders it in the sidebar across all pages.