### PR TITLE
🐛 fix(release): generate docstrfmt-compatible changelog entries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,10 +81,10 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           header=" $VERSION ($(date -u +%Y-%m-%d))"
-          separator=$(printf '%0.s*' $(seq 1 ${#header}))
+          separator=$(printf '%0.s*' $(seq 1 $((${#header} + 1))))
           {
             head -4 docs/changelog.rst
-            printf '%s\n%s\n%s\n%s\n\n' "$separator" "$header" "$separator" "$CHANGELOG"
+            printf '%s\n%s\n%s\n\n%s\n\n' "$separator" "$header" "$separator" "$CHANGELOG"
             tail -n +5 docs/changelog.rst
           } > docs/changelog.tmp
           mv docs/changelog.tmp docs/changelog.rst

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,9 +2,10 @@
  Changelog
 ###########
 
-*******************
+********************
  4.9.4 (2026-03-05)
-*******************
+********************
+
 - [pre-commit.ci] pre-commit autoupdate :pr:`461` - by :user:`pre-commit-ci[bot]`
 - Update README.md
 - 📝 docs: add project logo to documentation :pr:`459`

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -61,7 +61,7 @@ def run() -> None:
 
 
 def _load_excluded_authors() -> set[str]:
-    release_config = ROOT / ".github" / "release.yml"
+    release_config = ROOT / ".github" / "release.yaml"
     if release_config.exists():
         with release_config.open(encoding="utf-8") as file_handler:
             config = yaml.safe_load(file_handler)


### PR DESCRIPTION
The release workflow generates RST section headers for new changelog entries that `docstrfmt` immediately reformats, causing pre-commit.ci to fail on every release commit. This happened on 4.9.4 ([pre-commit.ci run](https://results.pre-commit.ci/run/github/367032142/1772735654.mK4ebM_XRYWks2Prc5U9qg)) and was silently auto-fixed on earlier releases (4.9.2, etc.) by subsequent pre-commit.ci autoupdate PRs.

🔧 Two formatting issues: the `*` overline/underline separator matched the title length exactly, but `docstrfmt` expects it to be one character wider (to account for the leading space in RST overlined headers). Additionally, no blank line was emitted between the section underline and the bullet list. Both are now corrected in the `printf` format string.

A secondary bug is also fixed: `_load_excluded_authors` in `tasks/changelog.py` still referenced `.github/release.yml`, which was renamed to `.github/release.yaml` in b10b8c5. This caused bot commits (`dependabot[bot]`, `pre-commit-ci[bot]`) to appear in the 4.9.4 changelog instead of being filtered out.