### PR TITLE
🔧 fix(type): resolve ty 0.0.25 type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ test = [
   "pytest-mock>=3.15.1",
 ]
 type = [
-  "ty>=0.0.19,<0.0.25",
+  "ty>=0.0.19",
   { include-group = "release" },
   { include-group = "test" },
 ]

--- a/src/platformdirs/_xdg.py
+++ b/src/platformdirs/_xdg.py
@@ -21,7 +21,7 @@ class XDGMixin(PlatformDirsABC):
     def _site_data_dirs(self) -> list[str]:
         if xdg_dirs := os.environ.get("XDG_DATA_DIRS", "").strip():
             return [self._append_app_name_and_version(p) for p in xdg_dirs.split(os.pathsep) if p.strip()]
-        return super()._site_data_dirs  # type: ignore[misc]
+        return super()._site_data_dirs
 
     @property
     def site_data_dir(self) -> str:
@@ -40,7 +40,7 @@ class XDGMixin(PlatformDirsABC):
     def _site_config_dirs(self) -> list[str]:
         if xdg_dirs := os.environ.get("XDG_CONFIG_DIRS", "").strip():
             return [self._append_app_name_and_version(p) for p in xdg_dirs.split(os.pathsep) if p.strip()]
-        return super()._site_config_dirs  # type: ignore[misc]
+        return super()._site_config_dirs
 
     @property
     def site_config_dir(self) -> str:
@@ -129,7 +129,7 @@ class XDGMixin(PlatformDirsABC):
     def _site_applications_dirs(self) -> list[str]:
         if xdg_dirs := os.environ.get("XDG_DATA_DIRS", "").strip():
             return [os.path.join(p, "applications") for p in xdg_dirs.split(os.pathsep) if p.strip()]  # noqa: PTH118
-        return super()._site_applications_dirs  # type: ignore[misc]
+        return super()._site_applications_dirs
 
     @property
     def site_applications_dir(self) -> str:

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -124,6 +124,10 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
         """:returns: data directory shared by users"""
 
     @property
+    def _site_data_dirs(self) -> list[str]:
+        raise NotImplementedError
+
+    @property
     @abstractmethod
     def user_config_dir(self) -> str:
         """:returns: config directory tied to the user"""
@@ -132,6 +136,10 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
     @abstractmethod
     def site_config_dir(self) -> str:
         """:returns: config directory shared by users"""
+
+    @property
+    def _site_config_dirs(self) -> list[str]:
+        raise NotImplementedError
 
     @property
     @abstractmethod
@@ -212,6 +220,10 @@ class PlatformDirsABC(ABC):  # noqa: PLR0904
     @abstractmethod
     def site_applications_dir(self) -> str:
         """:returns: applications directory shared by users"""
+
+    @property
+    def _site_applications_dirs(self) -> list[str]:
+        raise NotImplementedError
 
     @property
     @abstractmethod

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -198,7 +198,7 @@ def _setup_ctypes_mocks(mocker: MockerFixture, *, win_dll: MagicMock | None = No
         if not hasattr(ctypes, attr):
             setattr(ctypes, attr, MagicMock())
     if win_dll is not None:
-        ctypes.WinDLL = win_dll  # type: ignore[attr-defined]
+        mocker.patch.object(ctypes, "WinDLL", win_dll)
     mocker.patch("sys.platform", "win32")
     mocker.patch("ctypes.POINTER", return_value=MagicMock())
 
@@ -227,8 +227,12 @@ def test_get_win_folder_via_ctypes_passes_dont_verify_flag(mocker: MockerFixture
     mock_ole32 = MagicMock()
     mock_shell32 = MagicMock()
     mock_kernel32 = MagicMock()
-    ctypes.WinDLL = MagicMock(  # type: ignore[attr-defined]
-        side_effect=lambda name: {"ole32": mock_ole32, "shell32": mock_shell32, "kernel32": mock_kernel32}[name],
+    mocker.patch.object(
+        ctypes,
+        "WinDLL",
+        MagicMock(
+            side_effect=lambda name: {"ole32": mock_ole32, "shell32": mock_shell32, "kernel32": mock_kernel32}[name],
+        ),
     )
 
     mocker.patch("ctypes.byref", side_effect=lambda x: x)
@@ -273,8 +277,12 @@ def test_get_win_folder_via_ctypes_null_result(mocker: MockerFixture) -> None:
     mock_ole32 = MagicMock()
     mock_shell32 = MagicMock()
     mock_kernel32 = MagicMock()
-    ctypes.WinDLL = MagicMock(  # type: ignore[attr-defined]
-        side_effect=lambda name: {"ole32": mock_ole32, "shell32": mock_shell32, "kernel32": mock_kernel32}[name],
+    mocker.patch.object(
+        ctypes,
+        "WinDLL",
+        MagicMock(
+            side_effect=lambda name: {"ole32": mock_ole32, "shell32": mock_shell32, "kernel32": mock_kernel32}[name],
+        ),
     )
 
     mocker.patch("ctypes.byref", side_effect=lambda x: x)


### PR DESCRIPTION
ty 0.0.25 introduced stricter type checking. This PR fixes the actual type errors and removes the temporary version pin.

Changes:
- Add `_site_data_dirs`, `_site_config_dirs`, `_site_applications_dirs` as concrete properties on `PlatformDirsABC` so `XDGMixin.super()` calls resolve
- Replace direct `ctypes.WinDLL` assignment with `mocker.patch.object` in tests
- Remove `# type: ignore[misc]` comments from `_xdg.py`
- Remove `ty<0.0.25` version pin