### PR TITLE
🐛 fix(release): use double quotes for tag variable expansion

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
       - name: Create temporary tag for hatch-vcs
         if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: git tag '${STEPS_V_OUTPUTS_VERSION}'
+        run: git tag "${STEPS_V_OUTPUTS_VERSION}"
         env:
           STEPS_V_OUTPUTS_VERSION: ${{ steps.v.outputs.version }}
       - name: Build package


### PR DESCRIPTION
The release workflow's "Create temporary tag for hatch-vcs" step uses single quotes around `${STEPS_V_OUTPUTS_VERSION}`, which prevents bash from expanding the variable. The tag is created as the literal string `${STEPS_V_OUTPUTS_VERSION}` instead of e.g. `4.9.5`. Because `hatch-vcs` never finds a valid version tag on the commit, it falls back to `git describe` and produces a version like `4.9.5.dev13+g104d28b48`. PyPI then rejects the upload with `400 Bad Request` since local version identifiers aren't allowed.

Switching to double quotes fixes the expansion so the temporary tag matches the computed version and `hatch-vcs` produces a clean release version.