### PR TITLE
🐛 fix(windows): stop leaking memory on repeated folder lookups

### DIFF
--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -302,10 +303,11 @@ _KNOWN_FOLDER_GUIDS: dict[str, str] = {
 }
 
 
-def get_win_folder_via_ctypes(csidl_name: str) -> str:
-    """Get folder via :func:`SHGetKnownFolderPath`.
+@cache
+def _build_get_win_folder_via_ctypes() -> Callable[[str], str]:
+    """Build the resolver once; a fresh ``_GUID`` per call leaks ctypes pointer types.
 
-    See https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath.
+    See https://github.com/tox-dev/platformdirs/issues/501.
 
     """
     if sys.platform != "win32":  # only needed for type checker to know that this code runs only on Windows
@@ -334,29 +336,41 @@ def get_win_folder_via_ctypes(csidl_name: str) -> str:
     kernel32.GetShortPathNameW.restype = wintypes.DWORD
     kernel32.GetShortPathNameW.argtypes = [wintypes.LPWSTR, wintypes.LPWSTR, wintypes.DWORD]
 
-    folder_guid = _KNOWN_FOLDER_GUIDS.get(csidl_name)
-    if folder_guid is None:
-        msg = f"Unknown CSIDL name: {csidl_name}"
-        raise ValueError(msg)
+    def resolve(csidl_name: str) -> str:
+        folder_guid = _KNOWN_FOLDER_GUIDS.get(csidl_name)
+        if folder_guid is None:
+            msg = f"Unknown CSIDL name: {csidl_name}"
+            raise ValueError(msg)
 
-    guid = _GUID()
-    ole32.CLSIDFromString(folder_guid, byref(guid))
+        guid = _GUID()
+        ole32.CLSIDFromString(folder_guid, byref(guid))
 
-    path_ptr = wintypes.LPWSTR()
-    shell32.SHGetKnownFolderPath(byref(guid), _KF_FLAG_DONT_VERIFY, None, byref(path_ptr))
-    result = path_ptr.value
-    ole32.CoTaskMemFree(path_ptr)
+        path_ptr = wintypes.LPWSTR()
+        shell32.SHGetKnownFolderPath(byref(guid), _KF_FLAG_DONT_VERIFY, None, byref(path_ptr))
+        result = path_ptr.value
+        ole32.CoTaskMemFree(path_ptr)
 
-    if result is None:
-        msg = f"SHGetKnownFolderPath returned NULL for {csidl_name}"
-        raise ValueError(msg)
+        if result is None:
+            msg = f"SHGetKnownFolderPath returned NULL for {csidl_name}"
+            raise ValueError(msg)
 
-    if any(ord(c) > 255 for c in result):  # noqa: PLR2004
-        buf = create_unicode_buffer(1024)
-        if kernel32.GetShortPathNameW(result, buf, 1024):
-            result = buf.value
+        if any(ord(c) > 255 for c in result):  # noqa: PLR2004
+            buf = create_unicode_buffer(1024)
+            if kernel32.GetShortPathNameW(result, buf, 1024):
+                result = buf.value
 
-    return result
+        return result
+
+    return resolve
+
+
+def get_win_folder_via_ctypes(csidl_name: str) -> str:
+    """Get folder via :func:`SHGetKnownFolderPath`.
+
+    See https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath.
+
+    """
+    return _build_get_win_folder_via_ctypes()(csidl_name)
 
 
 def _pick_get_win_folder() -> Callable[[str], str]:

--- a/src/platformdirs/windows.py
+++ b/src/platformdirs/windows.py
@@ -283,8 +283,8 @@ def get_win_folder_from_registry(csidl_name: str) -> str:
     # Use HKEY_LOCAL_MACHINE for system-wide folders, HKEY_CURRENT_USER for user-specific folders
     hkey = winreg.HKEY_LOCAL_MACHINE if csidl_name in machine_names else winreg.HKEY_CURRENT_USER
 
-    key = winreg.OpenKey(hkey, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders")
-    directory, _ = winreg.QueryValueEx(key, shell_folder_name)
+    with winreg.OpenKey(hkey, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") as key:
+        directory, _ = winreg.QueryValueEx(key, shell_folder_name)
     return str(directory)
 
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -281,6 +281,28 @@ def test_get_win_folder_via_ctypes_unknown_csidl(mocker: MockerFixture) -> None:
             _cleanup_ctypes_mocks()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="mock-based call counting only runs on non-Windows")
+def test_get_win_folder_via_ctypes_builds_once(mocker: MockerFixture) -> None:
+    """Repeated calls must reuse one resolver so ctypes pointer types are not leaked (issue #501)."""
+    _setup_ctypes_mocks(mocker)
+
+    win_dll = MagicMock(side_effect=lambda _name: MagicMock())
+    mocker.patch.object(ctypes, "WinDLL", win_dll)
+    mocker.patch("ctypes.byref", side_effect=lambda x: x)
+    mocker.patch("ctypes.wintypes.LPWSTR", return_value=MagicMock(value=r"C:\Users\Test\AppData\Local"))
+
+    try:
+        importlib.reload(windows)
+        from platformdirs.windows import get_win_folder_via_ctypes as fresh_fn  # noqa: PLC0415
+
+        for _ in range(5):
+            fresh_fn("CSIDL_LOCAL_APPDATA")
+    finally:
+        _cleanup_ctypes_mocks()
+
+    assert win_dll.call_count == 3  # ole32, shell32, kernel32 loaded once total, not once per call
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="cannot force NULL from real SHGetKnownFolderPath")
 def test_get_win_folder_via_ctypes_null_result(mocker: MockerFixture) -> None:
     _setup_ctypes_mocks(mocker)


### PR DESCRIPTION
Looking up a Windows folder path in a loop leaked memory. A service that builds a cache path with `platformdirs.user_data_path` about once a second grew by gigabytes of retained RAM over a few hours, as issue https://github.com/tox-dev/platformdirs/issues/501 reports. 🐛 Each call to `get_win_folder_via_ctypes` defined a new `_GUID` `Structure` subclass, and every `POINTER(_GUID)` registered an entry in `ctypes._pointer_type_cache` that nothing released.

The change builds the `_GUID` class and the three DLL bindings once behind `functools.cache` and runs a resolver closure over them on each call. `get_win_folder_via_ctypes` keeps its signature and delegates to the cached builder, so the fallback selector and every caller stay the same. A second commit closes the registry-fallback key with a context manager rather than leaving the OS handle for the garbage collector to reclaim.

I confirmed the fix by exercising the real function 10,000 times, stubbing only `WinDLL` and `sys.platform` so `POINTER` and `Structure` still run. On Python 3.13 the cache and the retained `_GUID` classes stop growing, and memray reports a large drop in peak memory. ✨

| Python 3.13, 10,000 calls | `ctypes._pointer_type_cache` | live `_GUID` classes | memray peak |
| --- | --- | --- | --- |
| before | 3 → 10,021 | 0 → 10,000 | 66.8 MiB |
| after | 3 → 22 | 0 → 1 | 1.9 MiB |

Python 3.14 already reworked `_pointer_type_cache` upstream, which hides the cache symptom on that version, while the retained-object growth it fixes is version-independent. Returned paths are unchanged.
