### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -15,6 +16,7 @@ copyright = "2021, The platformdirs team"  # ruff:ignore[builtin-variable-shadow
 release = __version__
 version = release
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.extlinks",
@@ -58,3 +60,5 @@ towncrier_draft_include_empty = True  # keep the docs build green right after a 
 towncrier_draft_working_directory = Path(__file__).parent.parent
 # Towncrier news fragments are rST snippets folded into changelog.rst at release; they are not standalone pages.
 exclude_patterns = ["changelog/*"]
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ docs = [
   "sphinx-autodoc-typehints>=3.9.2",
   "sphinx-copybutton>=0.5.2",
   "sphinx-design>=0.7",
+  "sphinx-llm>=0.4.1",
   "sphinx-sitemap>=2.9",
   "sphinxcontrib-mermaid>=2",
   "sphinxcontrib-towncrier>=0.5.0a0",


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
