### PR TITLE
fix: stop iter_*_dirs yielding the same directory twice

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -277,7 +277,8 @@ Windows. Executables here are available to all users.
 
 These methods are available on :class:`~platformdirs.PlatformDirs` instances. They yield both user and site directories
 for a given type, enabling configuration merging and fallback patterns. See :ref:`howto:Merging config from multiple
-sources` for a practical example.
+sources` for a practical example. Each directory is yielded once, so platforms and configurations where a site directory
+resolves to its user equivalent produce a shorter list rather than a repeated entry.
 
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_data_dirs` / :meth:`~platformdirs.api.PlatformDirsABC.iter_data_paths`
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_config_dirs` /

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -277,9 +277,8 @@ Windows. Executables here are available to all users.
 
 These methods are available on :class:`~platformdirs.PlatformDirs` instances. They yield both user and site directories
 for a given type, enabling configuration merging and fallback patterns. See :ref:`howto:Merging config from multiple
-sources` for a practical example. Each distinct directory appears once. When a site directory resolves to the same path
-as its user equivalent, as on Android and for the runtime directories on Windows and macOS, the iterator produces a
-single entry.
+sources` for a practical example. User directories come first, then site directories, and each distinct directory
+appears once.
 
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_data_dirs` / :meth:`~platformdirs.api.PlatformDirsABC.iter_data_paths`
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_config_dirs` /

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -277,8 +277,9 @@ Windows. Executables here are available to all users.
 
 These methods are available on :class:`~platformdirs.PlatformDirs` instances. They yield both user and site directories
 for a given type, enabling configuration merging and fallback patterns. See :ref:`howto:Merging config from multiple
-sources` for a practical example. Each directory is yielded once, so platforms and configurations where a site directory
-resolves to its user equivalent produce a shorter list rather than a repeated entry.
+sources` for a practical example. Each distinct directory appears once. When a site directory resolves to the same path
+as its user equivalent, as on Android and for the runtime directories on Windows and macOS, the iterator produces a
+single entry.
 
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_data_dirs` / :meth:`~platformdirs.api.PlatformDirsABC.iter_data_paths`
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_config_dirs` /

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,9 +6,9 @@
 
 .. towncrier release notes start
 
-********************
+*********************
  4.11.3 (2026-08-13)
-********************
+*********************
 
 - ``python -m platformdirs`` now lists :func:`~platformdirs.user_desktop_dir`, which was missing from the properties it
   prints. :pr:`523`

--- a/docs/changelog/524.bugfix.rst
+++ b/docs/changelog/524.bugfix.rst
@@ -1,4 +1,4 @@
 Stop the ``iter_*_dirs`` methods yielding the same directory twice when a site directory resolves to its user equivalent
-- :pr:`520` fixed this only for Unix with ``use_site_for_root``. The duplicate also showed up in
-:meth:`~platformdirs.PlatformDirs.iter_runtime_dirs` on Unix with ``$XDG_RUNTIME_DIR`` set, on Windows and on macOS, and
-in all six iterators on Android. Callers that merge the yielded directories no longer read the same file twice.
+- :pr:`520` covered only Unix with ``use_site_for_root``. It also hit
+:meth:`~platformdirs.PlatformDirs.iter_runtime_dirs` on Unix with ``$XDG_RUNTIME_DIR`` set, on Windows and macOS, and
+all six iterators on Android.

--- a/docs/changelog/524.bugfix.rst
+++ b/docs/changelog/524.bugfix.rst
@@ -1,5 +1,4 @@
-Stop the ``iter_*_dirs`` methods yielding the same directory twice when a site directory resolves to its user
-equivalent. :pr:`520` fixed this for Unix when ``use_site_for_root`` is active, but it also happened on Unix for
-:meth:`~platformdirs.PlatformDirs.iter_runtime_dirs` whenever ``$XDG_RUNTIME_DIR`` is set, on Windows and macOS for
-:meth:`~platformdirs.PlatformDirs.iter_runtime_dirs`, and on Android for all six iterators. Each directory is now
-yielded once, so these cases return a shorter list rather than a repeated entry.
+Stop the ``iter_*_dirs`` methods yielding the same directory twice when a site directory resolves to its user equivalent
+- :pr:`520` fixed this only for Unix with ``use_site_for_root``. The duplicate also showed up in
+:meth:`~platformdirs.PlatformDirs.iter_runtime_dirs` on Unix with ``$XDG_RUNTIME_DIR`` set, on Windows and on macOS, and
+in all six iterators on Android. Callers that merge the yielded directories no longer read the same file twice.

--- a/docs/changelog/524.bugfix.rst
+++ b/docs/changelog/524.bugfix.rst
@@ -1,0 +1,5 @@
+Stop the ``iter_*_dirs`` methods yielding the same directory twice when a site directory resolves to its user
+equivalent. :pr:`520` fixed this for Unix when ``use_site_for_root`` is active, but it also happened on Unix for
+:meth:`~platformdirs.PlatformDirs.iter_runtime_dirs` whenever ``$XDG_RUNTIME_DIR`` is set, on Windows and macOS for
+:meth:`~platformdirs.PlatformDirs.iter_runtime_dirs`, and on Android for all six iterators. Each directory is now
+yielded once, so these cases return a shorter list rather than a repeated entry.

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -402,53 +402,53 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
         """Runtime path shared by users."""
         return Path(self.site_runtime_dir)
 
-    def _iter_config_dirs(self) -> Iterator[str]:
-        yield self.user_config_dir
-        yield self.site_config_dir
-
     def iter_config_dirs(self) -> Iterator[str]:
         """:yield: all user and site configuration directories."""
         yield from _unique(self._iter_config_dirs())
 
-    def _iter_data_dirs(self) -> Iterator[str]:
-        yield self.user_data_dir
-        yield self.site_data_dir
+    def _iter_config_dirs(self) -> Iterator[str]:
+        yield self.user_config_dir
+        yield self.site_config_dir
 
     def iter_data_dirs(self) -> Iterator[str]:
         """:yield: all user and site data directories."""
         yield from _unique(self._iter_data_dirs())
 
-    def _iter_cache_dirs(self) -> Iterator[str]:
-        yield self.user_cache_dir
-        yield self.site_cache_dir
+    def _iter_data_dirs(self) -> Iterator[str]:
+        yield self.user_data_dir
+        yield self.site_data_dir
 
     def iter_cache_dirs(self) -> Iterator[str]:
         """:yield: all user and site cache directories."""
         yield from _unique(self._iter_cache_dirs())
 
-    def _iter_state_dirs(self) -> Iterator[str]:
-        yield self.user_state_dir
-        yield self.site_state_dir
+    def _iter_cache_dirs(self) -> Iterator[str]:
+        yield self.user_cache_dir
+        yield self.site_cache_dir
 
     def iter_state_dirs(self) -> Iterator[str]:
         """:yield: all user and site state directories."""
         yield from _unique(self._iter_state_dirs())
 
-    def _iter_log_dirs(self) -> Iterator[str]:
-        yield self.user_log_dir
-        yield self.site_log_dir
+    def _iter_state_dirs(self) -> Iterator[str]:
+        yield self.user_state_dir
+        yield self.site_state_dir
 
     def iter_log_dirs(self) -> Iterator[str]:
         """:yield: all user and site log directories."""
         yield from _unique(self._iter_log_dirs())
 
-    def _iter_runtime_dirs(self) -> Iterator[str]:
-        yield self.user_runtime_dir
-        yield self.site_runtime_dir
+    def _iter_log_dirs(self) -> Iterator[str]:
+        yield self.user_log_dir
+        yield self.site_log_dir
 
     def iter_runtime_dirs(self) -> Iterator[str]:
         """:yield: all user and site runtime directories."""
         yield from _unique(self._iter_runtime_dirs())
+
+    def _iter_runtime_dirs(self) -> Iterator[str]:
+        yield self.user_runtime_dir
+        yield self.site_runtime_dir
 
     def iter_config_paths(self) -> Iterator[Path]:
         """:yield: all user and site configuration paths."""

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -483,6 +483,8 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
 
 def _unique(dirs: Iterable[str]) -> Iterator[str]:
     """:yield: ``dirs`` in order, skipping any directory already yielded."""
+    # Lazy on purpose: under ensure_exists reading a site_*_dir creates it, so draining ``dirs`` up front would
+    # create directories for a caller that stops after the first entry.
     seen: set[str] = set()
     for path in dirs:
         if path not in seen:

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from typing import Literal
 
 
@@ -402,35 +402,53 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
         """Runtime path shared by users."""
         return Path(self.site_runtime_dir)
 
-    def iter_config_dirs(self) -> Iterator[str]:
-        """:yield: all user and site configuration directories."""
+    def _iter_config_dirs(self) -> Iterator[str]:
         yield self.user_config_dir
         yield self.site_config_dir
 
-    def iter_data_dirs(self) -> Iterator[str]:
-        """:yield: all user and site data directories."""
+    def iter_config_dirs(self) -> Iterator[str]:
+        """:yield: all user and site configuration directories."""
+        yield from _unique(self._iter_config_dirs())
+
+    def _iter_data_dirs(self) -> Iterator[str]:
         yield self.user_data_dir
         yield self.site_data_dir
 
-    def iter_cache_dirs(self) -> Iterator[str]:
-        """:yield: all user and site cache directories."""
+    def iter_data_dirs(self) -> Iterator[str]:
+        """:yield: all user and site data directories."""
+        yield from _unique(self._iter_data_dirs())
+
+    def _iter_cache_dirs(self) -> Iterator[str]:
         yield self.user_cache_dir
         yield self.site_cache_dir
 
-    def iter_state_dirs(self) -> Iterator[str]:
-        """:yield: all user and site state directories."""
+    def iter_cache_dirs(self) -> Iterator[str]:
+        """:yield: all user and site cache directories."""
+        yield from _unique(self._iter_cache_dirs())
+
+    def _iter_state_dirs(self) -> Iterator[str]:
         yield self.user_state_dir
         yield self.site_state_dir
 
-    def iter_log_dirs(self) -> Iterator[str]:
-        """:yield: all user and site log directories."""
+    def iter_state_dirs(self) -> Iterator[str]:
+        """:yield: all user and site state directories."""
+        yield from _unique(self._iter_state_dirs())
+
+    def _iter_log_dirs(self) -> Iterator[str]:
         yield self.user_log_dir
         yield self.site_log_dir
 
-    def iter_runtime_dirs(self) -> Iterator[str]:
-        """:yield: all user and site runtime directories."""
+    def iter_log_dirs(self) -> Iterator[str]:
+        """:yield: all user and site log directories."""
+        yield from _unique(self._iter_log_dirs())
+
+    def _iter_runtime_dirs(self) -> Iterator[str]:
         yield self.user_runtime_dir
         yield self.site_runtime_dir
+
+    def iter_runtime_dirs(self) -> Iterator[str]:
+        """:yield: all user and site runtime directories."""
+        yield from _unique(self._iter_runtime_dirs())
 
     def iter_config_paths(self) -> Iterator[Path]:
         """:yield: all user and site configuration paths."""
@@ -461,3 +479,12 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
         """:yield: all user and site runtime paths."""
         for path in self.iter_runtime_dirs():
             yield Path(path)
+
+
+def _unique(dirs: Iterable[str]) -> Iterator[str]:
+    """:yield: ``dirs`` in order, skipping any directory already yielded."""
+    seen: set[str] = set()
+    for path in dirs:
+        if path not in seen:
+            seen.add(path)
+            yield path

--- a/src/platformdirs/macos.py
+++ b/src/platformdirs/macos.py
@@ -197,18 +197,15 @@ class _MacOSDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         """Runtime directory shared by users, same as `user_runtime_dir`."""
         return self.user_runtime_dir
 
-    def iter_config_dirs(self) -> Iterator[str]:
-        """:yield: all user and site configuration directories."""
+    def _iter_config_dirs(self) -> Iterator[str]:
         yield self.user_config_dir
         yield from self._site_config_dirs
 
-    def iter_data_dirs(self) -> Iterator[str]:
-        """:yield: all user and site data directories."""
+    def _iter_data_dirs(self) -> Iterator[str]:
         yield self.user_data_dir
         yield from self._site_data_dirs
 
-    def iter_cache_dirs(self) -> Iterator[str]:
-        """:yield: all user and site cache directories."""
+    def _iter_cache_dirs(self) -> Iterator[str]:
         yield self.user_cache_dir
         yield from self._site_cache_dirs
 

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -227,6 +227,8 @@ class _UnixDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
     def _iter_config_dirs(self) -> Iterator[str]:
+        # Under multipath the user dir is an os.pathsep-joined string that equals no single site entry, so the
+        # deduplication in iter_config_dirs cannot drop it. Skip it here instead.
         if not self._use_site:
             yield self.user_config_dir
         yield from self._site_config_dirs

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -226,38 +226,32 @@ class _UnixDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         """Cache path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
         return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
-    def iter_config_dirs(self) -> Iterator[str]:
-        """:yield: all user and site configuration directories."""
+    def _iter_config_dirs(self) -> Iterator[str]:
         if not self._use_site:
             yield self.user_config_dir
         yield from self._site_config_dirs
 
-    def iter_data_dirs(self) -> Iterator[str]:
-        """:yield: all user and site data directories."""
+    def _iter_data_dirs(self) -> Iterator[str]:
         if not self._use_site:
             yield self.user_data_dir
         yield from self._site_data_dirs
 
-    def iter_cache_dirs(self) -> Iterator[str]:
-        """:yield: all user and site cache directories."""
+    def _iter_cache_dirs(self) -> Iterator[str]:
         if not self._use_site:
             yield self.user_cache_dir
         yield self.site_cache_dir
 
-    def iter_state_dirs(self) -> Iterator[str]:
-        """:yield: all user and site state directories."""
+    def _iter_state_dirs(self) -> Iterator[str]:
         if not self._use_site:
             yield self.user_state_dir
         yield self.site_state_dir
 
-    def iter_log_dirs(self) -> Iterator[str]:
-        """:yield: all user and site log directories."""
+    def _iter_log_dirs(self) -> Iterator[str]:
         if not self._use_site:
             yield self.user_log_dir
         yield self.site_log_dir
 
-    def iter_runtime_dirs(self) -> Iterator[str]:
-        """:yield: all user and site runtime directories."""
+    def _iter_runtime_dirs(self) -> Iterator[str]:
         if not self._use_site:
             yield self.user_runtime_dir
         yield self.site_runtime_dir

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+@pytest.fixture
+def _example_android_folder(mocker: MockerFixture) -> None:
+    mocker.patch("platformdirs.android._android_folder", return_value="/data/data/com.example", autospec=True)
+    mocker.patch("platformdirs.android.os.path.join", lambda *args: "/".join(args))
+
+
 @pytest.mark.parametrize(
     "params",
     [
@@ -31,9 +37,8 @@ if TYPE_CHECKING:
         "app_name_author_version_false_opinion",
     ],
 )
-def test_android(mocker: MockerFixture, params: dict[str, Any], func: str) -> None:
-    mocker.patch("platformdirs.android._android_folder", return_value="/data/data/com.example", autospec=True)
-    mocker.patch("platformdirs.android.os.path.join", lambda *args: "/".join(args))
+@pytest.mark.usefixtures("_example_android_folder")
+def test_android(params: dict[str, Any], func: str) -> None:
     result = getattr(Android(**params), func)
 
     suffix_elements = []
@@ -203,8 +208,7 @@ def test_android_ensure_exists_creates_opinion_subdir(
         pytest.param("iter_runtime_dirs", "/data/data/com.example/cache/foo/tmp", id="runtime"),
     ],
 )
-def test_android_iter_dirs_no_duplicates(mocker: MockerFixture, func: str, expected: str) -> None:
-    mocker.patch("platformdirs.android._android_folder", return_value="/data/data/com.example", autospec=True)
-    mocker.patch("platformdirs.android.os.path.join", lambda *args: "/".join(args))
+@pytest.mark.usefixtures("_example_android_folder")
+def test_android_iter_dirs_no_duplicates(func: str, expected: str) -> None:
     # Every site_*_dir on Android is defined as its user_*_dir.
     assert list(getattr(Android(appname="foo"), func)()) == [expected]

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -195,16 +195,16 @@ def test_android_ensure_exists_creates_opinion_subdir(
 @pytest.mark.parametrize(
     ("func", "expected"),
     [
-        ("iter_config_dirs", "/data/data/com.example/shared_prefs/foo"),
-        ("iter_data_dirs", "/data/data/com.example/files/foo"),
-        ("iter_cache_dirs", "/data/data/com.example/cache/foo"),
-        ("iter_state_dirs", "/data/data/com.example/files/foo"),
-        ("iter_log_dirs", "/data/data/com.example/cache/foo/log"),
-        ("iter_runtime_dirs", "/data/data/com.example/cache/foo/tmp"),
+        pytest.param("iter_config_dirs", "/data/data/com.example/shared_prefs/foo", id="config"),
+        pytest.param("iter_data_dirs", "/data/data/com.example/files/foo", id="data"),
+        pytest.param("iter_cache_dirs", "/data/data/com.example/cache/foo", id="cache"),
+        pytest.param("iter_state_dirs", "/data/data/com.example/files/foo", id="state"),
+        pytest.param("iter_log_dirs", "/data/data/com.example/cache/foo/log", id="log"),
+        pytest.param("iter_runtime_dirs", "/data/data/com.example/cache/foo/tmp", id="runtime"),
     ],
 )
 def test_android_iter_dirs_no_duplicates(mocker: MockerFixture, func: str, expected: str) -> None:
     mocker.patch("platformdirs.android._android_folder", return_value="/data/data/com.example", autospec=True)
     mocker.patch("platformdirs.android.os.path.join", lambda *args: "/".join(args))
-    # Every site_*_dir on Android is defined as its user_*_dir, so each iterator has a single directory to yield.
+    # Every site_*_dir on Android is defined as its user_*_dir.
     assert list(getattr(Android(appname="foo"), func)()) == [expected]

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -190,3 +190,21 @@ def test_android_ensure_exists_creates_opinion_subdir(
     expected = str(cache_dir / "myapp" / subdir)
     assert result == expected
     assert Path(result).is_dir()
+
+
+@pytest.mark.parametrize(
+    ("func", "expected"),
+    [
+        ("iter_config_dirs", "/data/data/com.example/shared_prefs/foo"),
+        ("iter_data_dirs", "/data/data/com.example/files/foo"),
+        ("iter_cache_dirs", "/data/data/com.example/cache/foo"),
+        ("iter_state_dirs", "/data/data/com.example/files/foo"),
+        ("iter_log_dirs", "/data/data/com.example/cache/foo/log"),
+        ("iter_runtime_dirs", "/data/data/com.example/cache/foo/tmp"),
+    ],
+)
+def test_android_iter_dirs_no_duplicates(mocker: MockerFixture, func: str, expected: str) -> None:
+    mocker.patch("platformdirs.android._android_folder", return_value="/data/data/com.example", autospec=True)
+    mocker.patch("platformdirs.android.os.path.join", lambda *args: "/".join(args))
+    # Every site_*_dir on Android is defined as its user_*_dir, so each iterator has a single directory to yield.
+    assert list(getattr(Android(appname="foo"), func)()) == [expected]

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -441,6 +441,6 @@ def test_macos_ensure_exists_preexisting_dir(mocker: MockerFixture, tmp_path: Pa
 @pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
 def test_macos_iter_runtime_dirs_no_duplicate() -> None:
     home = str(Path("~").expanduser())
+    # site_runtime_dir is defined as user_runtime_dir.
     expected = os.path.join(f"{home}/Library/Caches/TemporaryItems", "foo")  # ruff:ignore[os-path-join]
-    # site_runtime_dir is defined as user_runtime_dir, so the iterator has a single directory to yield.
     assert list(MacOS(appname="foo").iter_runtime_dirs()) == [expected]

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -436,3 +436,11 @@ def test_macos_ensure_exists_preexisting_dir(mocker: MockerFixture, tmp_path: Pa
     # Calling again with an already-existing directory must not raise.
     second = dirs.user_data_dir
     assert first == second
+
+
+@pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
+def test_macos_iter_runtime_dirs_no_duplicate() -> None:
+    home = str(Path("~").expanduser())
+    expected = os.path.join(f"{home}/Library/Caches/TemporaryItems", "foo")  # ruff:ignore[os-path-join]
+    # site_runtime_dir is defined as user_runtime_dir, so the iterator has a single directory to yield.
+    assert list(MacOS(appname="foo").iter_runtime_dirs()) == [expected]

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -44,6 +44,16 @@ def _clear_xdg_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
+def home() -> str:
+    return str(Path("~").expanduser())
+
+
+@pytest.fixture
+def _homebrew_py_prefix(mocker: MockerFixture) -> None:
+    mocker.patch("sys.prefix", "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13")
+
+
+@pytest.fixture
 def _builtin_py_prefix(mocker: MockerFixture) -> None:
     """Keep ``sys.prefix`` off the ``/opt/python`` Homebrew heuristic so directories use the system defaults."""
     py_version = sys.version_info
@@ -63,10 +73,9 @@ def _builtin_py_prefix(mocker: MockerFixture) -> None:
     ],
 )
 @pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
-def test_macos(params: dict[str, Any], func: str) -> None:
+def test_macos(home: str, params: dict[str, Any], func: str) -> None:
     result = getattr(MacOS(**params), func)
 
-    home = str(Path("~").expanduser())
     suffix_elements = tuple(params[i] for i in ("appname", "version") if i in params)
     suffix = os.sep.join(("", *suffix_elements)) if suffix_elements else ""  # ruff:ignore[os-path-join]
 
@@ -126,7 +135,9 @@ def test_macos(params: dict[str, Any], func: str) -> None:
 )
 @pytest.mark.parametrize("multipath", [pytest.param(True, id="multipath"), pytest.param(False, id="singlepath")])
 @pytest.mark.usefixtures("_clear_xdg_env")
-def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath: bool, site_func: str) -> None:
+def test_macos_homebrew(
+    mocker: MockerFixture, home: str, params: dict[str, Any], multipath: bool, site_func: str
+) -> None:
     test_data = [
         {
             "sys_prefix": "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13",
@@ -146,7 +157,6 @@ def test_macos_homebrew(mocker: MockerFixture, params: dict[str, Any], multipath
 
         result = getattr(MacOS(multipath=multipath, **params), site_func)
 
-        home = str(Path("~").expanduser())
         suffix_elements = tuple(params[i] for i in ("appname", "version") if i in params)
         suffix = os.sep.join(("", *suffix_elements)) if suffix_elements else ""  # ruff:ignore[os-path-join]
 
@@ -258,9 +268,8 @@ def test_macos_xdg_media_dirs(monkeypatch: pytest.MonkeyPatch, env_var: str, pro
     ],
 )
 @pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
-def test_macos_xdg_empty_falls_back(monkeypatch: pytest.MonkeyPatch, env_var: str, prop: str) -> None:
+def test_macos_xdg_empty_falls_back(monkeypatch: pytest.MonkeyPatch, home: str, env_var: str, prop: str) -> None:
     monkeypatch.setenv(env_var, "")
-    home = str(Path("~").expanduser())
     expected_map = {
         "user_data_dir": f"{home}/Library/Application Support",
         "user_config_dir": f"{home}/Library/Application Support",
@@ -329,19 +338,15 @@ def test_iter_config_dirs_xdg(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dirs == ["/xdg/config", "/xdg/etc1", "/xdg/etc2"]
 
 
-@pytest.mark.usefixtures("_clear_xdg_env")
-def test_iter_data_dirs_homebrew(mocker: MockerFixture) -> None:
-    mocker.patch("sys.prefix", "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13")
+@pytest.mark.usefixtures("_clear_xdg_env", "_homebrew_py_prefix")
+def test_iter_data_dirs_homebrew(home: str) -> None:
     dirs = list(MacOS().iter_data_dirs())
-    home = str(Path("~").expanduser())
     assert dirs == [f"{home}/Library/Application Support", "/opt/homebrew/share", "/Library/Application Support"]
 
 
-@pytest.mark.usefixtures("_clear_xdg_env")
-def test_iter_config_dirs_homebrew(mocker: MockerFixture) -> None:
-    mocker.patch("sys.prefix", "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13")
+@pytest.mark.usefixtures("_clear_xdg_env", "_homebrew_py_prefix")
+def test_iter_config_dirs_homebrew(home: str) -> None:
     dirs = list(MacOS().iter_config_dirs())
-    home = str(Path("~").expanduser())
     assert dirs == [f"{home}/Library/Application Support", "/opt/homebrew/share", "/Library/Application Support"]
 
 
@@ -368,27 +373,22 @@ def test_site_dirs_fall_back_when_xdg_var_is_all_separators(
     assert getattr(MacOS(appname="foo"), prop) == expected
 
 
-@pytest.mark.usefixtures("_clear_xdg_env")
+@pytest.mark.usefixtures("_clear_xdg_env", "_homebrew_py_prefix")
 @pytest.mark.parametrize("multipath", [True, False])
-def test_iter_cache_dirs_homebrew(mocker: MockerFixture, multipath: bool) -> None:
-    mocker.patch("sys.prefix", "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13")
+def test_iter_cache_dirs_homebrew(home: str, multipath: bool) -> None:
     dirs = list(MacOS(multipath=multipath).iter_cache_dirs())
-    home = str(Path("~").expanduser())
     assert dirs == [f"{home}/Library/Caches", "/opt/homebrew/var/cache", "/Library/Caches"]
 
 
-@pytest.mark.usefixtures("_clear_xdg_env")
-def test_iter_cache_paths_homebrew_multipath(mocker: MockerFixture) -> None:
-    mocker.patch("sys.prefix", "/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13")
+@pytest.mark.usefixtures("_clear_xdg_env", "_homebrew_py_prefix")
+def test_iter_cache_paths_homebrew_multipath(home: str) -> None:
     paths = list(MacOS(multipath=True).iter_cache_paths())
-    home = str(Path("~").expanduser())
     assert paths == [Path(f"{home}/Library/Caches"), Path("/opt/homebrew/var/cache"), Path("/Library/Caches")]
 
 
 @pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
-def test_iter_data_dirs_no_homebrew() -> None:
+def test_iter_data_dirs_no_homebrew(home: str) -> None:
     dirs = list(MacOS().iter_data_dirs())
-    home = str(Path("~").expanduser())
     assert dirs == [f"{home}/Library/Application Support", "/Library/Application Support"]
 
 
@@ -421,9 +421,8 @@ def test_no_xdg_site_dirs_leak(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
-def test_macos_site_runtime_path() -> None:
+def test_macos_site_runtime_path(home: str) -> None:
     result = MacOS(appname="foo").site_runtime_path
-    home = str(Path("~").expanduser())
     assert result == Path(f"{home}/Library/Caches/TemporaryItems/foo")
 
 
@@ -439,8 +438,7 @@ def test_macos_ensure_exists_preexisting_dir(mocker: MockerFixture, tmp_path: Pa
 
 
 @pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
-def test_macos_iter_runtime_dirs_no_duplicate() -> None:
-    home = str(Path("~").expanduser())
+def test_macos_iter_runtime_dirs_no_duplicate(home: str) -> None:
     # site_runtime_dir is defined as user_runtime_dir.
     expected = os.path.join(f"{home}/Library/Caches/TemporaryItems", "foo")  # ruff:ignore[os-path-join]
     assert list(MacOS(appname="foo").iter_runtime_dirs()) == [expected]

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -24,6 +24,26 @@ def _reload_after_test() -> typing.Iterator[None]:
     importlib.reload(unix)
 
 
+@pytest.fixture
+def _as_root(mocker: MockerFixture) -> None:
+    mocker.patch("platformdirs.unix.getuid", return_value=0)
+
+
+@pytest.fixture
+def _as_non_root(mocker: MockerFixture) -> None:
+    mocker.patch("platformdirs.unix.getuid", return_value=1000)
+
+
+@pytest.fixture
+def _writable_runtime_dir(mocker: MockerFixture) -> None:
+    mocker.patch("os.access", return_value=True)
+
+
+@pytest.fixture
+def _no_xdg_runtime_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+
 @pytest.mark.parametrize(
     "prop",
     [
@@ -442,40 +462,30 @@ _SITE_REDIRECT_CASES: list[tuple[str, str]] = [
 ]
 
 
+@pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir")
 @pytest.mark.parametrize(("prop", "expected"), _SITE_REDIRECT_CASES)
-def test_use_site_for_root_as_root(
-    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch, prop: str, expected: str
-) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=0)
-    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+def test_use_site_for_root_as_root(prop: str, expected: str) -> None:
     result = getattr(Unix(appname="foo", use_site_for_root=True), prop)
     assert result == expected
 
 
+@pytest.mark.usefixtures("_as_non_root", "_no_xdg_runtime_dir", "_writable_runtime_dir")
 @pytest.mark.parametrize(("prop", "expected"), _SITE_REDIRECT_CASES)
-def test_use_site_for_root_as_non_root(
-    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch, prop: str, expected: str
-) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=1000)
-    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-    mocker.patch("os.access", return_value=True)
+def test_use_site_for_root_as_non_root(prop: str, expected: str) -> None:
     dirs = Unix(appname="foo", use_site_for_root=True)
     result = getattr(dirs, prop)
     assert result != expected
 
 
+@pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir", "_writable_runtime_dir")
 @pytest.mark.parametrize(("prop", "expected"), _SITE_REDIRECT_CASES)
-def test_use_site_for_root_disabled_as_root(
-    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch, prop: str, expected: str
-) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=0)
-    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-    mocker.patch("os.access", return_value=True)
+def test_use_site_for_root_disabled_as_root(prop: str, expected: str) -> None:
     dirs = Unix(appname="foo", use_site_for_root=False)
     result = getattr(dirs, prop)
     assert result != expected
 
 
+@pytest.mark.usefixtures("_as_root")
 @pytest.mark.parametrize(
     ("xdg_var", "prop", "expected_site"),
     [
@@ -487,15 +497,15 @@ def test_use_site_for_root_disabled_as_root(
     ],
 )
 def test_use_site_for_root_bypasses_xdg_user_vars(
-    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch, xdg_var: str, prop: str, expected_site: str
+    monkeypatch: pytest.MonkeyPatch, xdg_var: str, prop: str, expected_site: str
 ) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=0)
     monkeypatch.setenv(xdg_var, "/custom/xdg/path")
     monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
     result = getattr(Unix(appname="foo", use_site_for_root=True), prop)
     assert result == expected_site
 
 
+@pytest.mark.usefixtures("_as_root")
 @pytest.mark.parametrize(
     ("xdg_var", "func"),
     [
@@ -504,12 +514,10 @@ def test_use_site_for_root_bypasses_xdg_user_vars(
     ],
 )
 def test_use_site_iter_dirs_no_duplicates(
-    mocker: MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
     xdg_var: str,
     func: Callable[[Unix], Iterator[str]],
 ) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=0)
     monkeypatch.setenv(xdg_var, "/custom/xdg/path")
     result = func(Unix(appname="foo", use_site_for_root=True))
     assert list(result) == [os.path.join("/custom/xdg/path", "foo")]  # ruff:ignore[os-path-join]
@@ -529,43 +537,44 @@ _SINGLE_SITE_ITER_CASES = [
 ]
 
 
+@pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir")
 @pytest.mark.parametrize(("func", "expected"), _SINGLE_SITE_ITER_CASES)
 def test_use_site_iter_dirs_no_duplicates_single_site_dir(
-    mocker: MockerFixture,
-    monkeypatch: pytest.MonkeyPatch,
     func: Callable[[Unix], Iterator[str]],
     expected: str,
 ) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=0)
-    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
     result = func(Unix(appname="foo", use_site_for_root=True))
     assert list(result) == [expected]
 
 
+@pytest.mark.usefixtures("_as_non_root", "_no_xdg_runtime_dir", "_writable_runtime_dir")
 @pytest.mark.parametrize(("func", "expected"), _SINGLE_SITE_ITER_CASES)
 def test_iter_dirs_as_non_root_keeps_user_dir(
-    mocker: MockerFixture,
-    monkeypatch: pytest.MonkeyPatch,
     func: Callable[[Unix], Iterator[str]],
     expected: str,
 ) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=1000)
-    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-    mocker.patch("os.access", return_value=True)
     result = list(func(Unix(appname="foo", use_site_for_root=True)))
     assert len(result) == 2
     assert result[0] != expected
     assert result[1] == expected
 
 
-def test_iter_config_dirs_as_root_with_multipath_skips_joined_user_dir(
-    mocker: MockerFixture,
+@pytest.mark.usefixtures("_as_root")
+@pytest.mark.parametrize(
+    ("xdg_var", "func"),
+    [
+        ("XDG_CONFIG_DIRS", Unix.iter_config_dirs),
+        ("XDG_DATA_DIRS", Unix.iter_data_dirs),
+    ],
+)
+def test_iter_dirs_as_root_with_multipath_skips_joined_user_dir(
     monkeypatch: pytest.MonkeyPatch,
+    xdg_var: str,
+    func: Callable[[Unix], Iterator[str]],
 ) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=0)
-    monkeypatch.setenv("XDG_CONFIG_DIRS", f"/xdg/etc1{os.pathsep}/xdg/etc2")
-    dirs = Unix(multipath=True, use_site_for_root=True)
-    assert list(dirs.iter_config_dirs()) == ["/xdg/etc1", "/xdg/etc2"]
+    monkeypatch.setenv(xdg_var, f"/xdg/a{os.pathsep}/xdg/b")
+    # Under multipath the user dir is the joined string, which equals no single site entry for the dedupe to drop.
+    assert list(func(Unix(multipath=True, use_site_for_root=True))) == ["/xdg/a", "/xdg/b"]
 
 
 def test_iter_runtime_dirs_no_duplicate_with_xdg_runtime_dir(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -549,3 +549,10 @@ def test_iter_dirs_as_non_root_keeps_user_dir(
     assert len(result) == 2
     assert result[0] != expected
     assert result[1] == expected
+
+
+def test_iter_runtime_dirs_xdg_runtime_dir(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    mocker.patch("platformdirs.unix.getuid", return_value=1000)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    # $XDG_RUNTIME_DIR backs both the user and the site runtime directory, so there is only one to yield.
+    assert list(Unix(appname="foo").iter_runtime_dirs()) == [os.path.join("/run/user/1000", "foo")]  # ruff:ignore[os-path-join]

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -551,8 +551,7 @@ def test_iter_dirs_as_non_root_keeps_user_dir(
     assert result[1] == expected
 
 
-def test_iter_runtime_dirs_xdg_runtime_dir(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch) -> None:
-    mocker.patch("platformdirs.unix.getuid", return_value=1000)
+def test_iter_runtime_dirs_no_duplicate_with_xdg_runtime_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
-    # $XDG_RUNTIME_DIR backs both the user and the site runtime directory, so there is only one to yield.
+    # $XDG_RUNTIME_DIR backs both the user and the site runtime directory.
     assert list(Unix(appname="foo").iter_runtime_dirs()) == [os.path.join("/run/user/1000", "foo")]  # ruff:ignore[os-path-join]

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -340,6 +340,13 @@ def test_iter_config_dirs_xdg(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dirs == ["/xdg/config", "/xdg/etc1", "/xdg/etc2"]
 
 
+def test_iter_data_dirs_creates_only_the_consumed_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "user"))
+    monkeypatch.setenv("XDG_DATA_DIRS", str(tmp_path / "site"))
+    next(Unix(ensure_exists=True).iter_data_dirs())
+    assert not (tmp_path / "site").exists()
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -549,6 +556,16 @@ def test_iter_dirs_as_non_root_keeps_user_dir(
     assert len(result) == 2
     assert result[0] != expected
     assert result[1] == expected
+
+
+def test_iter_config_dirs_as_root_with_multipath_skips_joined_user_dir(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mocker.patch("platformdirs.unix.getuid", return_value=0)
+    monkeypatch.setenv("XDG_CONFIG_DIRS", f"/xdg/etc1{os.pathsep}/xdg/etc2")
+    dirs = Unix(multipath=True, use_site_for_root=True)
+    assert list(dirs.iter_config_dirs()) == ["/xdg/etc1", "/xdg/etc2"]
 
 
 def test_iter_runtime_dirs_no_duplicate_with_xdg_runtime_dir(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -438,8 +438,7 @@ def test_get_win_folder_override_strips_whitespace(monkeypatch: pytest.MonkeyPat
     assert get_win_folder("CSIDL_LOCAL_APPDATA") == r"X:\custom"
 
 
-def test_windows_iter_runtime_dirs_no_duplicate(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("platformdirs.windows._resolve_win_folder", lambda csidl: _WIN_FOLDERS[csidl])
-    # site_runtime_dir is defined as user_runtime_dir, so the iterator has a single directory to yield.
-    expected = os.path.join(_WIN_FOLDERS["CSIDL_LOCAL_APPDATA"], "Temp", "bar", "foo")  # ruff:ignore[os-path-join]
+def test_windows_iter_runtime_dirs_no_duplicate() -> None:
+    # site_runtime_dir is defined as user_runtime_dir.
+    expected = os.path.join(_LOCAL, "Temp", "bar", "foo")  # ruff:ignore[os-path-join]
     assert list(Windows(appname="foo", appauthor="bar").iter_runtime_dirs()) == [expected]

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -436,3 +436,10 @@ def test_get_win_folder_override_strips_whitespace(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr("platformdirs.windows._resolve_win_folder", lambda csidl: _WIN_FOLDERS[csidl])
     monkeypatch.setenv("WIN_PD_OVERRIDE_LOCAL_APPDATA", "  X:\\custom  ")
     assert get_win_folder("CSIDL_LOCAL_APPDATA") == r"X:\custom"
+
+
+def test_windows_iter_runtime_dirs_no_duplicate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("platformdirs.windows._resolve_win_folder", lambda csidl: _WIN_FOLDERS[csidl])
+    # site_runtime_dir is defined as user_runtime_dir, so the iterator has a single directory to yield.
+    expected = os.path.join(_WIN_FOLDERS["CSIDL_LOCAL_APPDATA"], "Temp", "bar", "foo")  # ruff:ignore[os-path-join]
+    assert list(Windows(appname="foo", appauthor="bar").iter_runtime_dirs()) == [expected]


### PR DESCRIPTION
#520 fixed this for the Unix `use_site_for_root` case, but the problem is more general: whenever a `site_*_dir` resolves to the same string as its `user_*_dir`, the iterator hands the caller that directory twice. Code that merges config or data files, the use case `docs/howto.rst` recommends these iterators for, then reads and applies the same file twice.

The case most likely to bite is Unix `iter_runtime_dirs()` with `XDG_RUNTIME_DIR` set, the normal state on any systemd system:

```python
>>> os.environ["XDG_RUNTIME_DIR"] = "/run/user/1000"
>>> list(Unix(appname="foo").iter_runtime_dirs())
['/run/user/1000/foo', '/run/user/1000/foo']
```

Both `user_runtime_dir` and `site_runtime_dir` read that variable, so the two entries are identical. It slipped through last time because the two tests #520 added both unset `XDG_RUNTIME_DIR` before asserting, leaving the common configuration untested.

Looking for the same shape elsewhere turned up more. Windows and macOS both define `site_runtime_dir` as `user_runtime_dir`, so their `iter_runtime_dirs()` duplicates too. Android defines every `site_*_dir` as its `user_*_dir`, so all six of its iterators returned a pair of identical paths.

Rather than override the iterators per platform a third time, `PlatformDirsABC` keeps the `yield user, yield site` logic in a protected `_iter_*_dirs` and deduplicates at the single public choke point. Unix and macOS override the protected hooks instead of the public methods, so their behaviour does not change and one place owns the invariant. The dedupe preserves order and still lets every distinct entry through; only exact repeats drop out.

Two things the dedupe rests on, each with a test:

- The `_use_site` guards in `_iter_config_dirs` and `_iter_data_dirs` survive the dedupe rather than becoming redundant. Under `multipath` the user dir is an `os.pathsep`-joined string that equals no single site entry, so nothing would drop it.
- `_unique` stays lazy. Under `ensure_exists` reading a `site_*_dir` creates it, so draining the source up front would create directories for a caller that stops after the first entry.

This is duplicate work rather than a wrong answer, so it stays latent for callers that only do existence checks. It matters for callers that accumulate.

Testing: full suite passes, plus a regression test per affected platform. I mutation-tested the new tests by replacing the dedupe with a passthrough and confirmed all nine fail, then restored it. `ty check --error-on-warning`, `ruff format --check` and the `-W` docs build are clean. Verified on Windows itself and the other platforms through the existing mocking fixtures.

One thing I noticed but did not touch: macOS `site_state_dir` is documented as "same as `site_data_dir`" but calls `_base_site_dirs()`, so it ignores `$XDG_DATA_DIRS` while `site_data_dir` honours it. That looks deliberate given there is no `XDG_STATE_DIRS` and Unix behaves the same way, so I left the code alone, but the docstring misleads either way. Happy to fix it here or separately.
