### PR TITLE
fix: accept app arguments in user_preference_dir

### DIFF
--- a/docs/changelog/531.bugfix.rst
+++ b/docs/changelog/531.bugfix.rst
@@ -1,4 +1,3 @@
 Give :func:`~platformdirs.user_preference_dir` and :func:`~platformdirs.user_preference_path` the same arguments as
-:func:`~platformdirs.user_config_dir`, the property they resolve to on Unix, Windows and Android. :pr:`491` added them
-next to the app-independent helpers such as :func:`~platformdirs.user_fonts_dir`, so they took no arguments and could
-only ever return the unscoped base directory even though the property they wrap appends the app name and version.
+:func:`~platformdirs.user_config_dir`. Added without arguments in :pr:`491`, they could only return the unscoped base
+directory even though the property they wrap appends the app name and version.

--- a/docs/changelog/531.bugfix.rst
+++ b/docs/changelog/531.bugfix.rst
@@ -1,0 +1,4 @@
+Give :func:`~platformdirs.user_preference_dir` and :func:`~platformdirs.user_preference_path` the same arguments as
+:func:`~platformdirs.user_config_dir`, the property they resolve to on Unix, Windows and Android. :pr:`491` added them
+next to the app-independent helpers such as :func:`~platformdirs.user_fonts_dir`, so they took no arguments and could
+only ever return the unscoped base directory even though the property they wrap appends the app name and version.

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -364,9 +364,32 @@ def user_fonts_dir() -> str:
     return PlatformDirs().user_fonts_dir
 
 
-def user_preference_dir() -> str:
-    """:returns: preference directory tied to the user"""
-    return PlatformDirs().user_preference_dir
+def user_preference_dir(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    roaming: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+) -> str:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: preference directory tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_preference_dir
 
 
 def user_bin_dir() -> str:
@@ -795,9 +818,32 @@ def user_fonts_path() -> Path:
     return PlatformDirs().user_fonts_path
 
 
-def user_preference_path() -> Path:
-    """:returns: preference path tied to the user"""
-    return PlatformDirs().user_preference_path
+def user_preference_path(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    roaming: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+) -> Path:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param roaming: See `roaming <platformdirs.api.PlatformDirsABC.roaming>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: preference path tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        roaming=roaming,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_preference_path
 
 
 def user_bin_path() -> Path:

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -364,13 +364,14 @@ def user_fonts_dir() -> str:
     return PlatformDirs().user_fonts_dir
 
 
-def user_preference_dir(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]
+def user_preference_dir(  # ruff:ignore[too-many-arguments]
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
     version: str | None = None,
-    roaming: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
+    roaming: bool = False,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
 ) -> str:
     """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
@@ -818,13 +819,14 @@ def user_fonts_path() -> Path:
     return PlatformDirs().user_fonts_path
 
 
-def user_preference_path(  # ruff:ignore[too-many-arguments, too-many-positional-arguments]
+def user_preference_path(  # ruff:ignore[too-many-arguments]
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
     version: str | None = None,
-    roaming: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
+    roaming: bool = False,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
 ) -> Path:
     """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,16 +67,16 @@ def test_site_applications_function_keeps_multipath_positional(func: str) -> Non
     assert positional == ["multipath", "ensure_exists"]
 
 
-def test_app_scoped_function_accepts_app_arguments(func: str) -> None:
-    # A module-level function is a thin wrapper over the matching PlatformDirs property, so it has to expose the
-    # arguments that property acts on. Where the property appends the app name and version, a function that cannot
-    # pass them can only ever return the unscoped base directory.
-    plain = getattr(platformdirs.PlatformDirs(), func)
+def test_function_matches_its_property_for_app_arguments(func: str) -> None:
+    function = getattr(platformdirs, func)
     scoped = getattr(platformdirs.PlatformDirs("MyApp", "MyCompany", version="1.0"), func)
-    parameters = inspect.Signature.from_callable(getattr(platformdirs, func)).parameters
-    if scoped != plain:
-        assert "appname" in parameters
-        assert "version" in parameters
+    if {"appname", "version"} <= inspect.Signature.from_callable(function).parameters.keys():
+        assert function(appname="MyApp", appauthor="MyCompany", version="1.0") == scoped
+    else:
+        # A function without the app arguments can only ever return the unscoped base directory, so a property that
+        # is app-scoped on any platform is out of its reach. Only one direction holds: a function may have to take
+        # arguments this platform ignores because another platform scopes the same property.
+        assert scoped == getattr(platformdirs.PlatformDirs(), func)
 
 
 @pytest.mark.parametrize("root", ["A", "/system", None])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,6 +67,18 @@ def test_site_applications_function_keeps_multipath_positional(func: str) -> Non
     assert positional == ["multipath", "ensure_exists"]
 
 
+def test_app_scoped_function_accepts_app_arguments(func: str) -> None:
+    # A module-level function is a thin wrapper over the matching PlatformDirs property, so it has to expose the
+    # arguments that property acts on. Where the property appends the app name and version, a function that cannot
+    # pass them can only ever return the unscoped base directory.
+    plain = getattr(platformdirs.PlatformDirs(), func)
+    scoped = getattr(platformdirs.PlatformDirs("MyApp", "MyCompany", version="1.0"), func)
+    parameters = inspect.Signature.from_callable(getattr(platformdirs, func)).parameters
+    if scoped != plain:
+        assert "appname" in parameters
+        assert "version" in parameters
+
+
 @pytest.mark.parametrize("root", ["A", "/system", None])
 @pytest.mark.parametrize("data", ["D", "/data", None])
 @pytest.mark.parametrize("path", ["/data/data/a/files", "/C"])


### PR DESCRIPTION
Differential check of the 54 module-level `*_dir` / `*_path` functions against the `PlatformDirs` properties they wrap: 0 value divergences in 12,960 comparisons, and 8 reach gaps. All 8 are `user_preference_dir` and `user_preference_path`.

Neither takes arguments, so neither can pass the app name or the version that the property acts on:

```pycon
>>> platformdirs.user_preference_dir()
'/Users/me/Library/Preferences'
>>> platformdirs.PlatformDirs("MyApp", version="1.0").user_preference_dir
'/Users/me/Library/Preferences/MyApp/1.0'
>>> platformdirs.user_preference_dir("MyApp", version="1.0")
TypeError: user_preference_dir() takes 0 positional arguments but 2 were given
```

macOS appends the app name and version to `~/Library/Preferences`. On the other three platforms `user_preference_dir` resolves to `user_config_dir`, which is app scoped as well. Either way the function can only return the unscoped base directory.

#491 added these two in one batch with app independent helpers such as `user_fonts_dir`, and the zero argument shape carried over to the one member of the batch it does not suit.

This gives both the signature of `user_config_dir`. Defaults are unchanged, so a no-argument call returns what it returns today.

The test asserts the invariant over every getter in `PROPS`: where the property varies with `appname` and `version`, the function must accept them. Reverting `__init__.py` fails it for `user_preference_dir` alone; the other 26 parametrizations pass either way, as pins.

Testing: full suite on macOS with 3.14, 1032 passed. The four `test_compatibility[site_data_dir-*]` failures reproduce on a clean `origin/main` worktree. Pinned ruff v0.16.4 is clean. Windows and Linux legs unrun here.

Drafted with Claude Code (Claude Opus 5). Not yet reviewed by a human; @dylanpulver will review before this is treated as ready.
