### PR TITLE
fix: return one site applications path for multipath

### DIFF
--- a/docs/changelog/532.bugfix.rst
+++ b/docs/changelog/532.bugfix.rst
@@ -1,0 +1,1 @@
+Make :func:`~platformdirs.site_applications_path` return the first site applications path when ``multipath=True`` instead of treating the joined directory list as one path.

--- a/docs/changelog/532.bugfix.rst
+++ b/docs/changelog/532.bugfix.rst
@@ -1,2 +1,3 @@
-Make :func:`~platformdirs.site_applications_path` return the first site applications path when ``multipath=True``
-instead of treating the joined directory list as one path.
+Make :func:`~platformdirs.site_applications_path` return the first entry on Unix when ``multipath=True``, matching
+:func:`~platformdirs.site_data_path`. It passed the whole ``$XDG_DATA_DIRS`` list to :class:`~pathlib.Path`, giving one
+unusable path such as ``/first/applications:/second/applications``.

--- a/docs/changelog/532.bugfix.rst
+++ b/docs/changelog/532.bugfix.rst
@@ -1,3 +1,3 @@
-Make :func:`~platformdirs.site_applications_path` return the first entry on Unix when ``multipath=True``, matching
-:func:`~platformdirs.site_data_path`. It passed the whole ``$XDG_DATA_DIRS`` list to :class:`~pathlib.Path`, giving one
-unusable path such as ``/first/applications:/second/applications``.
+Make :func:`~platformdirs.site_applications_path` return the first entry when ``multipath=True``, matching
+:func:`~platformdirs.site_data_path`. On Unix and macOS it passed the whole ``$XDG_DATA_DIRS`` list to
+:class:`~pathlib.Path`, giving one unusable path such as ``/first/applications:/second/applications``.

--- a/docs/changelog/532.bugfix.rst
+++ b/docs/changelog/532.bugfix.rst
@@ -1,1 +1,2 @@
-Make :func:`~platformdirs.site_applications_path` return the first site applications path when ``multipath=True`` instead of treating the joined directory list as one path.
+Make :func:`~platformdirs.site_applications_path` return the first site applications path when ``multipath=True``
+instead of treating the joined directory list as one path.

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -389,8 +389,8 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
 
     @property
     def site_applications_path(self) -> Path:
-        """Applications path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
-        return self._first_item_as_path_if_multipath(self.site_applications_dir)
+        """Applications path shared by users."""
+        return Path(self.site_applications_dir)
 
     @property
     def user_runtime_path(self) -> Path:

--- a/src/platformdirs/api.py
+++ b/src/platformdirs/api.py
@@ -389,8 +389,8 @@ class PlatformDirsABC(ABC):  # ruff:ignore[too-many-public-methods]
 
     @property
     def site_applications_path(self) -> Path:
-        """Applications path shared by users."""
-        return Path(self.site_applications_dir)
+        """Applications path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
+        return self._first_item_as_path_if_multipath(self.site_applications_dir)
 
     @property
     def user_runtime_path(self) -> Path:

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -226,6 +226,11 @@ class _UnixDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         """Cache path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
         return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
+    @property
+    def site_applications_path(self) -> Path:
+        """Applications path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
+        return self._first_item_as_path_if_multipath(self.site_applications_dir)
+
     def _iter_config_dirs(self) -> Iterator[str]:
         # Under multipath the user dir is an os.pathsep-joined string that equals no single site entry, so the
         # deduplication in iter_config_dirs cannot drop it. Skip it here instead.

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -226,11 +226,6 @@ class _UnixDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         """Cache path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
         return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
-    @property
-    def site_applications_path(self) -> Path:
-        """Applications path shared by users. Only return the first item, even if ``multipath`` is set to ``True``."""
-        return self._first_item_as_path_if_multipath(self.site_applications_dir)
-
     def _iter_config_dirs(self) -> Iterator[str]:
         # Under multipath the user dir is an os.pathsep-joined string that equals no single site entry, so the
         # deduplication in iter_config_dirs cannot drop it. Skip it here instead.

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -350,6 +350,12 @@ def test_iter_config_dirs_homebrew(home: str) -> None:
     assert dirs == [f"{home}/Library/Application Support", "/opt/homebrew/share", "/Library/Application Support"]
 
 
+@pytest.mark.usefixtures("_clear_xdg_env")
+def test_site_applications_path_multipath_returns_first_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_DATA_DIRS", f"/custom/first{os.pathsep}/custom/second")
+    assert MacOS(multipath=True).site_applications_path == Path("/custom/first/applications")
+
+
 @pytest.mark.usefixtures("_clear_xdg_env", "_builtin_py_prefix")
 @pytest.mark.parametrize(
     "value",

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import sys
 import typing
+from pathlib import Path
 from tempfile import gettempdir
 
 import pytest
@@ -13,7 +14,6 @@ from platformdirs.unix import Unix
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Iterator
-    from pathlib import Path
 
     from pytest_mock import MockerFixture
 
@@ -393,6 +393,11 @@ def test_site_data_dir_multipath_falls_back_when_xdg_var_is_all_separators(monke
     monkeypatch.setenv("XDG_DATA_DIRS", os.pathsep)
     dirs = [os.path.join("/usr/local/share", "foo"), os.path.join("/usr/share", "foo")]  # ruff:ignore[os-path-join]
     assert Unix(appname="foo", multipath=True).site_data_dir == os.pathsep.join(dirs)
+
+
+def test_site_applications_path_multipath_returns_first_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_DATA_DIRS", f"/custom/first{os.pathsep}/custom/second")
+    assert Unix(multipath=True).site_applications_path == Path("/custom/first/applications")
 
 
 def test_user_media_dir_from_user_dirs_file(


### PR DESCRIPTION
When `multipath=True`, `site_applications_dir` returns the entries from `XDG_DATA_DIRS` joined by `os.pathsep`. Its `Path` counterpart passed that entire string to `Path`, producing a single path such as `/first/applications:/second/applications` instead of a usable applications directory.

Use the same first-entry conversion as the existing site data, config, and cache path properties. The regression test covers two XDG data directories on Unix.

Testing: `uvx --with tox-uv tox run -e 3.13`; `uvx --with tox-uv tox run -e fix,type`.