### PR TITLE
docs: fix the iterator order claim in api.rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -277,8 +277,7 @@ Windows. Executables here are available to all users.
 
 These methods are available on :class:`~platformdirs.PlatformDirs` instances. They yield both user and site directories
 for a given type, enabling configuration merging and fallback patterns. See :ref:`howto:Merging config from multiple
-sources` for a practical example. User directories come first, then site directories, and each distinct directory
-appears once.
+sources` for a practical example. The most specific directory comes first, and each distinct directory appears once.
 
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_data_dirs` / :meth:`~platformdirs.api.PlatformDirsABC.iter_data_paths`
 - :meth:`~platformdirs.api.PlatformDirsABC.iter_config_dirs` /

--- a/docs/changelog/533.doc.rst
+++ b/docs/changelog/533.doc.rst
@@ -1,0 +1,2 @@
+Correct the ordering note on the iterator methods. ``use_site_for_root`` drops the user directory entirely, so the
+iterators are documented as yielding the most specific directory first rather than always yielding the user one.

--- a/src/platformdirs/unix.py
+++ b/src/platformdirs/unix.py
@@ -227,8 +227,8 @@ class _UnixDefaults(PlatformDirsABC):  # ruff:ignore[too-many-public-methods]
         return self._first_item_as_path_if_multipath(self.site_cache_dir)
 
     def _iter_config_dirs(self) -> Iterator[str]:
-        # Under multipath the user dir is an os.pathsep-joined string that equals no single site entry, so the
-        # deduplication in iter_config_dirs cannot drop it. Skip it here instead.
+        # Under multipath the user dir is an os.pathsep-joined string that no single site entry matches, so the
+        # dedupe in iter_config_dirs cannot drop it. Skip it here instead.
         if not self._use_site:
             yield self.user_config_dir
         yield from self._site_config_dirs

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -485,7 +485,7 @@ def test_use_site_for_root_disabled_as_root(prop: str, expected: str) -> None:
     assert result != expected
 
 
-@pytest.mark.usefixtures("_as_root")
+@pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir")
 @pytest.mark.parametrize(
     ("xdg_var", "prop", "expected_site"),
     [
@@ -500,7 +500,6 @@ def test_use_site_for_root_bypasses_xdg_user_vars(
     monkeypatch: pytest.MonkeyPatch, xdg_var: str, prop: str, expected_site: str
 ) -> None:
     monkeypatch.setenv(xdg_var, "/custom/xdg/path")
-    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
     result = getattr(Unix(appname="foo", use_site_for_root=True), prop)
     assert result == expected_site
 
@@ -539,20 +538,14 @@ _SINGLE_SITE_ITER_CASES = [
 
 @pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir")
 @pytest.mark.parametrize(("func", "expected"), _SINGLE_SITE_ITER_CASES)
-def test_use_site_iter_dirs_no_duplicates_single_site_dir(
-    func: Callable[[Unix], Iterator[str]],
-    expected: str,
-) -> None:
+def test_use_site_iter_dirs_no_duplicates_single_site_dir(func: Callable[[Unix], Iterator[str]], expected: str) -> None:
     result = func(Unix(appname="foo", use_site_for_root=True))
     assert list(result) == [expected]
 
 
 @pytest.mark.usefixtures("_as_non_root", "_no_xdg_runtime_dir", "_writable_runtime_dir")
 @pytest.mark.parametrize(("func", "expected"), _SINGLE_SITE_ITER_CASES)
-def test_iter_dirs_as_non_root_keeps_user_dir(
-    func: Callable[[Unix], Iterator[str]],
-    expected: str,
-) -> None:
+def test_iter_dirs_as_non_root_keeps_user_dir(func: Callable[[Unix], Iterator[str]], expected: str) -> None:
     result = list(func(Unix(appname="foo", use_site_for_root=True)))
     assert len(result) == 2
     assert result[0] != expected
@@ -573,7 +566,7 @@ def test_iter_dirs_as_root_with_multipath_skips_joined_user_dir(
     func: Callable[[Unix], Iterator[str]],
 ) -> None:
     monkeypatch.setenv(xdg_var, f"/xdg/a{os.pathsep}/xdg/b")
-    # Under multipath the user dir is the joined string, which equals no single site entry for the dedupe to drop.
+    # Under multipath the user dir is the joined string, which no single site entry matches.
     assert list(func(Unix(multipath=True, use_site_for_root=True))) == ["/xdg/a", "/xdg/b"]
 
 


### PR DESCRIPTION
Follow-up to #524, which landed and shipped in 4.11.4 before this review finished.

`docs/api.rst` now claims:

> User directories come first, then site directories, and each distinct directory appears once.

The first half is wrong when `use_site_for_root` is active and the process is root. `_iter_*_dirs` skips the user directory outright rather than yielding it first, so under `multipath` the first entry is a site directory that does not equal `user_*_dir`:

```pycon
>>> dirs = Unix(appname="foo", multipath=True, use_site_for_root=True)   # as root, XDG_CONFIG_DIRS=/xdg/a:/xdg/b
>>> dirs.user_config_dir
'/xdg/a/foo:/xdg/b/foo'
>>> list(dirs.iter_config_dirs())
['/xdg/a/foo', '/xdg/b/foo']
```

`test_iter_dirs_as_root_with_multipath_skips_joined_user_dir` already pins that behaviour, so the code is right and only the sentence is wrong. "The most specific directory comes first" holds in every configuration and still tells callers what they need to merge in the right direction.

Two cleanups in the same area while I was there. `test_use_site_for_root_bypasses_xdg_user_vars` kept an inline `monkeypatch.delenv("XDG_RUNTIME_DIR", ...)` after gaining the `_no_xdg_runtime_dir` fixture that does the same thing. And two test signatures stayed exploded across four lines only because a magic trailing comma survived the removal of their `mocker` and `monkeypatch` parameters; both fit on one line now.

No behaviour change. `tox -e fix`, `-e type`, `-e docs` clean, full suite passes.
