### PR TITLE
fix: accept app arguments in the applications functions

### DIFF
--- a/docs/changelog/534.bugfix.rst
+++ b/docs/changelog/534.bugfix.rst
@@ -1,4 +1,5 @@
 Give :func:`~platformdirs.user_applications_dir`, :func:`~platformdirs.user_applications_path`,
 :func:`~platformdirs.site_applications_dir` and :func:`~platformdirs.site_applications_path` the app arguments. Android
 scopes both applications directories to the app, so without them the functions could only return the unscoped base
-directory there.
+directory there. On the two site functions they are keyword-only, keeping ``multipath`` first positional as it has been
+since 4.9.0.

--- a/docs/changelog/534.bugfix.rst
+++ b/docs/changelog/534.bugfix.rst
@@ -1,0 +1,4 @@
+Give :func:`~platformdirs.user_applications_dir`, :func:`~platformdirs.user_applications_path`,
+:func:`~platformdirs.site_applications_dir` and :func:`~platformdirs.site_applications_path` the app arguments. Android
+scopes both applications directories to the app, so without them the functions could only return the unscoped base
+directory there.

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -379,22 +379,51 @@ def site_bin_dir() -> str:
     return PlatformDirs().site_bin_dir
 
 
-def user_applications_dir() -> str:
-    """:returns: applications directory tied to the user"""
-    return PlatformDirs().user_applications_dir
+def user_applications_dir(
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+) -> str:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: applications directory tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_applications_dir
 
 
 def site_applications_dir(
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
     multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
     ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
 ) -> str:
-    """:param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
 
     :returns: applications directory shared by users
 
     """
     return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
         multipath=multipath,
         ensure_exists=ensure_exists,
     ).site_applications_dir
@@ -780,22 +809,51 @@ def site_bin_path() -> Path:
     return PlatformDirs().site_bin_path
 
 
-def user_applications_path() -> Path:
-    """:returns: applications path tied to the user"""
-    return PlatformDirs().user_applications_path
+def user_applications_path(
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
+    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+) -> Path:
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: applications path tied to the user
+
+    """
+    return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
+        ensure_exists=ensure_exists,
+        use_site_for_root=use_site_for_root,
+    ).user_applications_path
 
 
 def site_applications_path(
+    appname: str | None = None,
+    appauthor: str | Literal[False] | None = None,
+    version: str | None = None,
     multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
     ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
 ) -> Path:
-    """:param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
+    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
+    :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
+    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
     :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
 
     :returns: applications path shared by users
 
     """
     return PlatformDirs(
+        appname=appname,
+        appauthor=appauthor,
+        version=version,
         multipath=multipath,
         ensure_exists=ensure_exists,
     ).site_applications_path

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -405,17 +405,18 @@ def user_applications_dir(
 
 
 def site_applications_dir(
+    multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
     version: str | None = None,
-    multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
 ) -> str:
-    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    """:param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
-    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
 
     :returns: applications directory shared by users
 
@@ -835,17 +836,18 @@ def user_applications_path(
 
 
 def site_applications_path(
+    multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
     version: str | None = None,
-    multipath: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
 ) -> Path:
-    """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
+    """:param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
+    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
+    :param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
     :param version: See `version <platformdirs.api.PlatformDirsABC.version>`.
-    :param multipath: See `multipath <platformdirs.api.PlatformDirsABC.multipath>`.
-    :param ensure_exists: See `ensure_exists <platformdirs.api.PlatformDirsABC.ensure_exists>`.
 
     :returns: applications path shared by users
 

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -220,11 +220,11 @@ _SCOPED_APPLICATIONS_DIR: Final[str] = "/data/data/com.example/files/foo/1.0"
 def test_android_applications_dir_function_takes_app_arguments(mocker: MockerFixture, func: str) -> None:
     mocker.patch("platformdirs.PlatformDirs", Android)
     # Android scopes both applications directories to the app, so the function has to forward the name and version.
-    assert getattr(platformdirs, func)("foo", version="1.0") == _SCOPED_APPLICATIONS_DIR
+    assert getattr(platformdirs, func)(appname="foo", version="1.0") == _SCOPED_APPLICATIONS_DIR
 
 
 @pytest.mark.parametrize("func", ["user_applications_path", "site_applications_path"])
 @pytest.mark.usefixtures("_example_android_folder")
 def test_android_applications_path_function_takes_app_arguments(mocker: MockerFixture, func: str) -> None:
     mocker.patch("platformdirs.PlatformDirs", Android)
-    assert getattr(platformdirs, func)("foo", version="1.0") == Path(_SCOPED_APPLICATIONS_DIR)
+    assert getattr(platformdirs, func)(appname="foo", version="1.0") == Path(_SCOPED_APPLICATIONS_DIR)

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import platformdirs
 from platformdirs.android import Android
 
 if TYPE_CHECKING:
@@ -212,3 +213,14 @@ def test_android_ensure_exists_creates_opinion_subdir(
 def test_android_iter_dirs_no_duplicates(func: str, expected: str) -> None:
     # Every site_*_dir on Android is defined as its user_*_dir.
     assert list(getattr(Android(appname="foo"), func)()) == [expected]
+
+
+@pytest.mark.parametrize(
+    "func",
+    ["user_applications_dir", "user_applications_path", "site_applications_dir", "site_applications_path"],
+)
+@pytest.mark.usefixtures("_example_android_folder")
+def test_android_applications_function_takes_app_arguments(mocker: MockerFixture, func: str) -> None:
+    mocker.patch("platformdirs.PlatformDirs", Android)
+    # Android scopes both applications directories to the app, so the function has to forward the name and version.
+    assert str(getattr(platformdirs, func)("foo", version="1.0")) == "/data/data/com.example/files/foo/1.0"

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,8 +11,6 @@ import platformdirs
 from platformdirs.android import Android
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from pytest_mock import MockerFixture
 
 
@@ -184,8 +183,6 @@ def test_android_ensure_exists_creates_opinion_subdir(
     prop: str,
     subdir: str,
 ) -> None:
-    from pathlib import Path  # ruff:ignore[import-outside-top-level]
-
     mocker.patch("platformdirs.android._android_folder", return_value=str(tmp_path), autospec=True)
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir()
@@ -215,12 +212,19 @@ def test_android_iter_dirs_no_duplicates(func: str, expected: str) -> None:
     assert list(getattr(Android(appname="foo"), func)()) == [expected]
 
 
-@pytest.mark.parametrize(
-    "func",
-    ["user_applications_dir", "user_applications_path", "site_applications_dir", "site_applications_path"],
-)
+_SCOPED_APPLICATIONS_DIR: Final[str] = "/data/data/com.example/files/foo/1.0"
+
+
+@pytest.mark.parametrize("func", ["user_applications_dir", "site_applications_dir"])
 @pytest.mark.usefixtures("_example_android_folder")
-def test_android_applications_function_takes_app_arguments(mocker: MockerFixture, func: str) -> None:
+def test_android_applications_dir_function_takes_app_arguments(mocker: MockerFixture, func: str) -> None:
     mocker.patch("platformdirs.PlatformDirs", Android)
     # Android scopes both applications directories to the app, so the function has to forward the name and version.
-    assert str(getattr(platformdirs, func)("foo", version="1.0")) == "/data/data/com.example/files/foo/1.0"
+    assert getattr(platformdirs, func)("foo", version="1.0") == _SCOPED_APPLICATIONS_DIR
+
+
+@pytest.mark.parametrize("func", ["user_applications_path", "site_applications_path"])
+@pytest.mark.usefixtures("_example_android_folder")
+def test_android_applications_path_function_takes_app_arguments(mocker: MockerFixture, func: str) -> None:
+    mocker.patch("platformdirs.PlatformDirs", Android)
+    assert getattr(platformdirs, func)("foo", version="1.0") == Path(_SCOPED_APPLICATIONS_DIR)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,14 @@ def test_function_interface_is_in_sync(func: str) -> None:
     assert function_dir_signature.parameters == function_path_signature.parameters
 
 
+@pytest.mark.parametrize("func", ["site_applications_dir", "site_applications_path"])
+def test_site_applications_function_keeps_multipath_positional(func: str) -> None:
+    # multipath has been the first positional argument since 4.9.0, so the app arguments are keyword-only.
+    parameters = inspect.Signature.from_callable(getattr(platformdirs, func)).parameters
+    positional = [name for name, param in parameters.items() if param.kind is param.POSITIONAL_OR_KEYWORD]
+    assert positional == ["multipath", "ensure_exists"]
+
+
 @pytest.mark.parametrize("root", ["A", "/system", None])
 @pytest.mark.parametrize("data", ["D", "/data", None])
 @pytest.mark.parametrize("path", ["/data/data/a/files", "/C"])


### PR DESCRIPTION
Found while reviewing #531, which fixes the same defect for `user_preference_dir`. Its differential was run on macOS, so it missed two more functions that only misbehave on Android.

Android defines `user_applications_dir` as `user_data_dir`, and `site_applications_dir` as `user_applications_dir`. Both are therefore scoped to the app name and version. The four module-level wrappers took no app arguments, so on Android they could only ever return the unscoped base directory:

```pycon
>>> Android(appname="foo", version="1.0").user_applications_dir
'/data/data/com.example/files/foo/1.0'
>>> platformdirs.user_applications_dir("foo", version="1.0")
TypeError: user_applications_dir() takes 0 positional arguments but 1 was given
```

`user_applications_dir` and `user_applications_path` get the `user_config_dir` arguments minus `roaming`, which none of the four platforms consult for this property. `site_applications_dir` and `site_applications_path` keep `multipath` and gain the same three app arguments as `site_data_dir`. Defaults are unchanged, so a no-argument call returns what it returns today, and the other three platforms ignore the app name for these properties.

The test drives the real `Android` class through the module functions, since the wrapper resolves `PlatformDirs` per host and CI never runs on Android. Reverting `__init__.py` fails all four parametrizations.

Independent of #531; the two can merge in either order. Together they close every reach gap I can find: I checked all 27 properties in `PROPS` against their functions on `Unix`, `MacOS`, `Windows` and `Android`, and with both branches applied there are none left.

Testing: `tox -e fix`, `-e type`, `-e docs` clean, full suite passes. The four `test_comp_with_appdirs[site_data_dir-*]` failures reproduce on a clean `origin/main` worktree from a local `XDG_DATA_DIRS`.
