### PR TITLE
refactor: keyword-only booleans on the applications functions

### DIFF
--- a/docs/changelog/534.bugfix.rst
+++ b/docs/changelog/534.bugfix.rst
@@ -2,4 +2,4 @@ Give :func:`~platformdirs.user_applications_dir`, :func:`~platformdirs.user_appl
 :func:`~platformdirs.site_applications_dir` and :func:`~platformdirs.site_applications_path` the app arguments. Android
 scopes both applications directories to the app, so without them the functions could only return the unscoped base
 directory there. On the two site functions they are keyword-only, keeping ``multipath`` first positional as it has been
-since 4.9.0.
+since 4.9.0; the two user functions take their boolean options keyword-only.

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -383,8 +383,9 @@ def user_applications_dir(
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
     version: str | None = None,
-    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
 ) -> str:
     """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.
@@ -814,8 +815,9 @@ def user_applications_path(
     appname: str | None = None,
     appauthor: str | Literal[False] | None = None,
     version: str | None = None,
-    ensure_exists: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
-    use_site_for_root: bool = False,  # ruff:ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
+    *,
+    ensure_exists: bool = False,
+    use_site_for_root: bool = False,
 ) -> Path:
     """:param appname: See `appname <platformdirs.api.PlatformDirsABC.appname>`.
     :param appauthor: See `appauthor <platformdirs.api.PlatformDirsABC.appauthor>`.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,14 @@ def test_function_interface_is_in_sync(func: str) -> None:
     assert function_dir_signature.parameters == function_path_signature.parameters
 
 
+@pytest.mark.parametrize("func", ["user_applications_dir", "user_applications_path"])
+def test_user_applications_function_boolean_options_are_keyword_only(func: str) -> None:
+    # These options have not shipped yet, so they can be keyword-only without breaking any caller.
+    parameters = inspect.Signature.from_callable(getattr(platformdirs, func)).parameters
+    positional = [name for name, param in parameters.items() if param.kind is param.POSITIONAL_OR_KEYWORD]
+    assert positional == ["appname", "appauthor", "version"]
+
+
 @pytest.mark.parametrize("func", ["site_applications_dir", "site_applications_path"])
 def test_site_applications_function_keeps_multipath_positional(func: str) -> None:
     # multipath has been the first positional argument since 4.9.0, so the app arguments are keyword-only.


### PR DESCRIPTION
Follow-up to the question on #531 about the FBT suppressions. They are only needed because the booleans are positional, which is the thing the rule objects to, and a `*` fixes the finding rather than silencing it.

Scoped to arguments that have never shipped, so nothing breaks. `user_applications_dir` and `user_applications_path` took no arguments in 4.11.4; the `ensure_exists` and `use_site_for_root` that #534 gave them are still unreleased, so no caller can be passing them positionally. Making them keyword-only now costs nothing and removes the four suppressions.

Released signatures are untouched. `site_applications_dir` and `site_applications_path` keep `multipath` and `ensure_exists` positional, as they have been since 4.9.0, and their suppressions stay. I checked every public function in `__init__.py` against the 4.11.4 tag: no released parameter changes name, position or kind.

I first wrote this as a sweep over all 55 functions and `PlatformDirs`, which would have taken the suppressions from 88 down to 17. That is not worth breaking every caller who passes a boolean positionally, so it is out. If you ever cut a major, the diff is easy to reproduce.

`appname`, `appauthor` and `version` stay positional throughout. A test pins the new shape so it does not quietly regress.

Testing: `tox -e fix`, `-e type`, `-e docs` clean, full suite passes. The four `test_comp_with_appdirs[site_data_dir-*]` failures reproduce on a clean `origin/main` worktree from a local `XDG_DATA_DIRS`.
