### PR TITLE
fix: accept use_site_for_root in the bin functions

### DIFF
--- a/docs/changelog/537.bugfix.rst
+++ b/docs/changelog/537.bugfix.rst
@@ -1,0 +1,3 @@
+Give :func:`~platformdirs.user_bin_dir` and :func:`~platformdirs.user_bin_path` the ``use_site_for_root`` argument. On
+Unix the property redirects root to :func:`~platformdirs.site_bin_dir` when it is set, but the module-level functions
+took no arguments, so the redirect was unreachable through them.

--- a/docs/changelog/537.bugfix.rst
+++ b/docs/changelog/537.bugfix.rst
@@ -1,3 +1,2 @@
-Give :func:`~platformdirs.user_bin_dir` and :func:`~platformdirs.user_bin_path` the ``use_site_for_root`` argument. On
-Unix the property redirects root to :func:`~platformdirs.site_bin_dir` when it is set, but the module-level functions
-took no arguments, so the redirect was unreachable through them.
+Give :func:`~platformdirs.user_bin_dir` and :func:`~platformdirs.user_bin_path` the ``use_site_for_root`` argument. They
+took none, so neither could reach the Unix redirect of root to :func:`~platformdirs.site_bin_dir`.

--- a/src/platformdirs/__init__.py
+++ b/src/platformdirs/__init__.py
@@ -393,9 +393,13 @@ def user_preference_dir(  # ruff:ignore[too-many-arguments]
     ).user_preference_dir
 
 
-def user_bin_dir() -> str:
-    """:returns: bin directory tied to the user"""
-    return PlatformDirs().user_bin_dir
+def user_bin_dir(*, use_site_for_root: bool = False) -> str:
+    """:param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: bin directory tied to the user
+
+    """
+    return PlatformDirs(use_site_for_root=use_site_for_root).user_bin_dir
 
 
 def site_bin_dir() -> str:
@@ -849,9 +853,13 @@ def user_preference_path(  # ruff:ignore[too-many-arguments]
     ).user_preference_path
 
 
-def user_bin_path() -> Path:
-    """:returns: bin path tied to the user"""
-    return PlatformDirs().user_bin_path
+def user_bin_path(*, use_site_for_root: bool = False) -> Path:
+    """:param use_site_for_root: See `use_site_for_root <platformdirs.api.PlatformDirsABC.use_site_for_root>`.
+
+    :returns: bin path tied to the user
+
+    """
+    return PlatformDirs(use_site_for_root=use_site_for_root).user_bin_path
 
 
 def site_bin_path() -> Path:

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -466,6 +466,7 @@ _SITE_REDIRECT_CASES: list[tuple[str, str]] = [
         ),
     ),
     ("user_bin_dir", "/usr/local/bin"),
+    ("user_applications_dir", f"/usr/local/share{os.sep}applications"),
 ]
 
 
@@ -485,21 +486,17 @@ def test_use_site_for_root_as_non_root(prop: str, expected: str) -> None:
 
 
 @pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir")
-@pytest.mark.parametrize("variant", ["dir", "path"])
+@pytest.mark.parametrize("suffix", ["dir", "path"])
 @pytest.mark.parametrize(("prop", "expected"), _SITE_REDIRECT_CASES)
 def test_use_site_for_root_reaches_the_module_function(
-    mocker: MockerFixture,
-    prop: str,
-    expected: str,
-    variant: str,
+    mocker: MockerFixture, prop: str, expected: str, suffix: str
 ) -> None:
-    # Every property the site redirect touches has to be reachable through the module-level function too.
+    # The module-level functions have to reach every property the site redirect touches.
     mocker.patch("platformdirs.PlatformDirs", Unix)
-    function = getattr(platformdirs, prop.replace("_dir", f"_{variant}"))
-    kwargs: dict[str, bool | str] = {"use_site_for_root": True}
-    if "appname" in inspect.Signature.from_callable(function).parameters:
-        kwargs["appname"] = "foo"
-    assert Path(function(**kwargs)) == Path(expected)
+    function = getattr(platformdirs, prop.removesuffix("dir") + suffix)
+    accepted = inspect.Signature.from_callable(function).parameters
+    options = {"use_site_for_root": True, "appname": "foo"}
+    assert Path(function(**{k: v for k, v in options.items() if k in accepted})) == Path(expected)
 
 
 @pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir", "_writable_runtime_dir")

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import os
 import sys
 import typing
@@ -9,6 +10,7 @@ from tempfile import gettempdir
 
 import pytest
 
+import platformdirs
 from platformdirs import unix
 from platformdirs.unix import Unix
 
@@ -480,6 +482,24 @@ def test_use_site_for_root_as_non_root(prop: str, expected: str) -> None:
     dirs = Unix(appname="foo", use_site_for_root=True)
     result = getattr(dirs, prop)
     assert result != expected
+
+
+@pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir")
+@pytest.mark.parametrize("variant", ["dir", "path"])
+@pytest.mark.parametrize(("prop", "expected"), _SITE_REDIRECT_CASES)
+def test_use_site_for_root_reaches_the_module_function(
+    mocker: MockerFixture,
+    prop: str,
+    expected: str,
+    variant: str,
+) -> None:
+    # Every property the site redirect touches has to be reachable through the module-level function too.
+    mocker.patch("platformdirs.PlatformDirs", Unix)
+    function = getattr(platformdirs, prop.replace("_dir", f"_{variant}"))
+    kwargs: dict[str, bool | str] = {"use_site_for_root": True}
+    if "appname" in inspect.Signature.from_callable(function).parameters:
+        kwargs["appname"] = "foo"
+    assert Path(function(**kwargs)) == Path(expected)
 
 
 @pytest.mark.usefixtures("_as_root", "_no_xdg_runtime_dir", "_writable_runtime_dir")


### PR DESCRIPTION
Follow-up to the reach gaps closed in #531 and #534, found by checking the rest of the module-level functions against the properties they wrap.

On Unix, the `user_bin_dir` property redirects root to `site_bin_dir` when `use_site_for_root` is set, the same way data/config/cache/state/log/runtime do. Of those seven redirected properties, `user_bin_dir` was the only one whose module-level function took no arguments, so the redirect was unreachable through the function API:

```pycon
>>> Unix(use_site_for_root=True).user_bin_dir  # as root
'/usr/local/bin'
>>> platformdirs.user_bin_dir(use_site_for_root=True)
TypeError: user_bin_dir() got an unexpected keyword argument 'use_site_for_root'
```

This gives `user_bin_dir` and `user_bin_path` the one argument that carries behaviour. The other constructor arguments would be dead weight here: no platform scopes its bin directories to the app, and no platform's bin property calls `_optionally_create_directory`, so `appname`/`version`/`ensure_exists` can't affect the result. The parameter is keyword-only since it has never shipped on these functions, per the reasoning in #534.

The new test runs every `_SITE_REDIRECT_CASES` entry through the module-level function as well, in both `_dir` and `_path` form. Checked it the hard way: reverting `__init__.py` fails exactly the `user_bin_dir` case with the original `TypeError`, and keeping the signature while dropping the forwarding fails on the value. The `_path` leg exists because my first version only covered `_dir` and a non-forwarding `user_bin_path` mutant slipped straight through it.

Testing: full suite on Windows with 3.14, 1072 passed / 94 skipped (baseline 1058/94), ruff and ty clean. Linux and macOS legs unrun here.
